### PR TITLE
fix(core): route send-to-agent to live idle sessions

### DIFF
--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -2098,6 +2098,47 @@ describe("send", () => {
     expect(mockRuntime.sendMessage).toHaveBeenCalledWith(makeHandle("rt-1"), "Fix the CI failures");
   });
 
+  it("marks a live non-working session as working after sending", async () => {
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "stuck",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+    vi.mocked(mockRuntime.getOutput).mockResolvedValueOnce("before").mockResolvedValueOnce("after");
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await sm.send("app-1", "Wake up and handle the CI failures");
+
+    expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
+      makeHandle("rt-1"),
+      "Wake up and handle the CI failures",
+    );
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("working");
+  });
+
+  it("prefers a live session over stale terminal metadata when sending", async () => {
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "done",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+    vi.mocked(mockRuntime.getOutput).mockResolvedValueOnce("before").mockResolvedValueOnce("after");
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await sm.send("app-1", "Resume and fix the failing checks");
+
+    expect(mockRuntime.create).not.toHaveBeenCalled();
+    expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
+      makeHandle("rt-1"),
+      "Resume and fix the failing checks",
+    );
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("working");
+  });
+
   it("restores a dead session before sending the message", async () => {
     const wsPath = join(tmpDir, "ws-app-1");
     mkdirSync(wsPath, { recursive: true });
@@ -2129,6 +2170,7 @@ describe("send", () => {
       makeHandle("rt-restored"),
       "Please fix the review comments",
     );
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("working");
   });
 
   it("resolves when delivery cannot be confirmed (message already sent)", async () => {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -2047,6 +2047,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
   async function send(sessionId: SessionId, message: string): Promise<void> {
     const { raw, sessionsDir, project } = requireSessionRecord(sessionId);
+    const persistedStatus = validateStatus(raw["status"]);
     const selectedAgent = raw["agent"] ?? project.agent ?? config.defaults.agent;
     if (selectedAgent === "opencode" && !asValidOpenCodeSessionId(raw["opencodeSessionId"])) {
       const discovered = await discoverOpenCodeSessionIdByTitle(
@@ -2153,11 +2154,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         } satisfies RuntimeHandle);
       const normalized = current.runtimeHandle ? current : { ...current, runtimeHandle: handle };
 
-      if (forceRestore || isRestorable(normalized)) {
+      if (forceRestore) {
         return restoreForDelivery(
-          forceRestore
-            ? "session needed to be restarted before delivery"
-            : "session is not running",
+          "session needed to be restarted before delivery",
           normalized,
         );
       }
@@ -2166,6 +2165,19 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         runtimePlugin.isAlive(handle).catch(() => true),
         agentPlugin.isProcessRunning(handle).catch(() => true),
       ]);
+
+      // Prefer the live runtime/process check over stale metadata status.
+      // Sessions can sit idle at their prompt with statuses like "done" or
+      // "stuck" while still accepting new input. If the runtime is alive and
+      // the agent process is still present, we should deliver directly instead
+      // of forcing a restore based only on the recorded status.
+      if (runtimeAlive && processRunning) {
+        return normalized;
+      }
+
+      if (isRestorable(normalized)) {
+        return restoreForDelivery("session is not running", normalized);
+      }
 
       if (!runtimeAlive || !processRunning) {
         return restoreForDelivery(
@@ -2238,6 +2250,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         }
         throw new Error(String(retryErr), { cause: retryErr });
       }
+    }
+
+    // A freshly delivered prompt means the session is actively working again,
+    // even if the last persisted status was idle/stuck/review-related.
+    if (!NON_RESTORABLE_STATUSES.has(persistedStatus)) {
+      updateMetadata(sessionsDir, sessionId, { status: "working" });
     }
   }
 


### PR DESCRIPTION
## Summary\n- prefer a live runtime + agent process over stale session status when delivering follow-up prompts\n- keep marking resumed sessions as `working` after a successful send\n- add regressions for live non-working sessions, including stale terminal metadata\n\n## Testing\n- pnpm run typecheck\n- pnpm test\n- pnpm run lint\n\nCloses #7