### PR TITLE
feat(core): deduplicate lifecycle webhook deliveries

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -9,6 +9,7 @@ import { writeMetadata, readMetadataRaw } from "../metadata.js";
 import { getSessionsDir, getProjectBaseDir } from "../paths.js";
 import type {
   OrchestratorConfig,
+  OrchestratorEvent,
   PluginRegistry,
   SessionManager,
   Session,
@@ -802,6 +803,193 @@ describe("check (single session)", () => {
     expect(mockNotifier.notify).toHaveBeenCalledWith(
       expect.objectContaining({ type: "merge.ready" }),
     );
+  });
+
+  it("shares the transition idempotency key with reaction notifications", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T11:00:00.000Z"));
+
+    config.notificationRouting.action = ["desktop"];
+    config.notificationRouting.info = ["desktop"];
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("approved"),
+      getPendingComments: vi.fn().mockResolvedValue([]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: true,
+        ciPassing: true,
+        approved: true,
+        noConflicts: true,
+        blockers: [],
+      }),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    vi.mocked(mockSessionManager.get).mockResolvedValueOnce(
+      makeSession({ status: "approved", pr: makePR() }),
+    );
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "approved",
+      project: "my-app",
+    });
+
+    const transitionLifecycle = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await transitionLifecycle.check("app-1");
+
+    const [transitionEvent] = vi.mocked(mockNotifier.notify).mock.calls[0] as [OrchestratorEvent];
+    expect(transitionEvent.type).toBe("merge.ready");
+    expect(transitionEvent.idempotencyKey).toMatch(/^[a-f0-9]{64}$/);
+
+    vi.mocked(mockNotifier.notify).mockClear();
+    vi.mocked(mockSessionManager.get).mockResolvedValueOnce(
+      makeSession({ status: "approved", pr: makePR() }),
+    );
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "approved",
+      project: "my-app",
+    });
+
+    const reactionLifecycle = createLifecycleManager({
+      config: {
+        ...config,
+        reactions: {
+          "approved-and-green": {
+            auto: true,
+            action: "notify",
+            priority: "action",
+          },
+        },
+      },
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await reactionLifecycle.check("app-1");
+
+    const [reactionEvent] = vi.mocked(mockNotifier.notify).mock.calls[0] as [OrchestratorEvent];
+    expect(reactionEvent.type).toBe("reaction.triggered");
+    expect(reactionEvent.idempotencyKey).toBe(transitionEvent.idempotencyKey);
+  });
+
+  it("deduplicates duplicate transition notifications across poll cycles", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T11:00:00.000Z"));
+
+    config.notificationRouting.action = ["desktop"];
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("approved"),
+      getPendingComments: vi.fn().mockResolvedValue([]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: true,
+        ciPassing: true,
+        approved: true,
+        noConflicts: true,
+        blockers: [],
+      }),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    vi.mocked(mockSessionManager.list)
+      .mockResolvedValueOnce([makeSession({ status: "approved", pr: makePR() })])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([makeSession({ status: "approved", pr: makePR() })])
+      .mockResolvedValue([]);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "approved",
+      project: "my-app",
+    });
+
+    const lifecycle = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    lifecycle.start(10_000);
+
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockNotifier.notify).toHaveBeenCalledTimes(1);
+
+      const [firstEvent] = vi.mocked(mockNotifier.notify).mock.calls[0] as [OrchestratorEvent];
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(mockNotifier.notify).toHaveBeenCalledTimes(1);
+      expect(getLifecycleLogs()).toContainEqual(
+        expect.objectContaining({
+          event: "notification.deduplicated",
+          eventType: "merge.ready",
+          idempotencyKey: firstEvent.idempotencyKey,
+        }),
+      );
+    } finally {
+      lifecycle.stop();
+    }
   });
 
   it("skips PR auto-detection when metadata disables it", async () => {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -10,7 +10,7 @@
  * Reference: scripts/claude-session-status, scripts/claude-review-check
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   SESSION_STATUS,
   PR_STATE,
@@ -76,6 +76,76 @@ function inferPriority(type: EventType): EventPriority {
   return "info";
 }
 
+const EVENT_IDEMPOTENCY_BUCKET_MS = 60_000;
+const RECENT_EVENT_TTL_MS = 120_000;
+
+function stableSerializeIdempotencyPart(value: unknown): string {
+  if (value === null || typeof value === "number" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+
+  if (typeof value === "string") {
+    return JSON.stringify(value);
+  }
+
+  if (typeof value === "bigint") {
+    return JSON.stringify(value.toString());
+  }
+
+  if (value instanceof Date) {
+    return JSON.stringify(value.toISOString());
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableSerializeIdempotencyPart(item)).join(",")}]`;
+  }
+
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const entries = Object.keys(record)
+      .sort()
+      .map(
+        (key) =>
+          `${JSON.stringify(key)}:${stableSerializeIdempotencyPart(record[key])}`,
+      );
+    return `{${entries.join(",")}}`;
+  }
+
+  return JSON.stringify(String(value));
+}
+
+function createScopedIdempotencyKey(opts: {
+  sessionId: SessionId;
+  scope: string;
+  parts?: ReadonlyArray<unknown>;
+  timestamp: Date;
+}): string {
+  const bucket = Math.floor(opts.timestamp.getTime() / EVENT_IDEMPOTENCY_BUCKET_MS);
+  const payload = stableSerializeIdempotencyPart([
+    opts.sessionId,
+    opts.scope,
+    ...(opts.parts ?? []),
+    bucket,
+  ]);
+
+  return createHash("sha256").update(payload).digest("hex");
+}
+
+function createTransitionIdempotencyKey(opts: {
+  sessionId: SessionId;
+  transition: EventType;
+  oldStatus: SessionStatus;
+  newStatus: SessionStatus;
+  timestamp: Date;
+}): string {
+  return createScopedIdempotencyKey({
+    sessionId: opts.sessionId,
+    scope: opts.transition,
+    parts: [opts.oldStatus, opts.newStatus],
+    timestamp: opts.timestamp,
+  });
+}
+
 /** Create an OrchestratorEvent with defaults filled in. */
 function createEvent(
   type: EventType,
@@ -85,18 +155,35 @@ function createEvent(
     message: string;
     priority?: EventPriority;
     data?: Record<string, unknown>;
+    timestamp?: Date;
+    idempotencyKey?: string;
   },
 ): OrchestratorEvent {
+  const timestamp = opts.timestamp ?? new Date();
+
   return {
     id: randomUUID(),
+    idempotencyKey:
+      opts.idempotencyKey ??
+      createScopedIdempotencyKey({
+        sessionId: opts.sessionId,
+        scope: type,
+        parts: [opts.message, opts.data ?? {}],
+        timestamp,
+      }),
     type,
     priority: opts.priority ?? inferPriority(type),
     sessionId: opts.sessionId,
     projectId: opts.projectId,
-    timestamp: new Date(),
+    timestamp,
     message: opts.message,
     data: opts.data ?? {},
   };
+}
+
+interface EventEmissionContext {
+  idempotencyKey?: string;
+  timestamp?: Date;
 }
 
 /** Determine which event type corresponds to a status transition. */
@@ -297,9 +384,30 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
   const states = new Map<SessionId, SessionStatus>();
   const reactionTrackers = new Map<string, ReactionTracker>(); // "sessionId:reactionKey"
+  const recentEmissions = new Map<string, number>();
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let polling = false; // re-entrancy guard
   let allCompleteEmitted = false; // guard against repeated all_complete
+
+  function pruneRecentEmissions(now = Date.now()): void {
+    for (const [key, expiresAt] of recentEmissions.entries()) {
+      if (expiresAt <= now) {
+        recentEmissions.delete(key);
+      }
+    }
+  }
+
+  function reserveEmission(idempotencyKey: string, now = Date.now()): boolean {
+    pruneRecentEmissions(now);
+    const expiresAt = recentEmissions.get(idempotencyKey);
+
+    if (typeof expiresAt === "number" && expiresAt > now) {
+      return false;
+    }
+
+    recentEmissions.set(idempotencyKey, now + RECENT_EVENT_TTL_MS);
+    return true;
+  }
 
   /** Check if idle time exceeds the agent-stuck threshold. */
   function isIdleBeyondThreshold(session: Session, idleTimestamp: Date): boolean {
@@ -605,6 +713,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     reactionKey: string,
     reactionConfig: ReactionConfig,
     pollStats?: LifecyclePollStats,
+    eventContext?: EventEmissionContext,
   ): Promise<ReactionResult> {
     const trackerKey = `${sessionId}:${reactionKey}`;
     let tracker = reactionTrackers.get(trackerKey);
@@ -644,6 +753,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         projectId,
         message: `Reaction '${reactionKey}' escalated after ${tracker.attempts} attempts`,
         data: { reactionKey, attempts: tracker.attempts },
+        timestamp: eventContext?.timestamp,
+        idempotencyKey: eventContext?.idempotencyKey,
       });
       logLifecycle("info", "reaction.escalated", {
         pollId: pollStats?.pollId,
@@ -712,6 +823,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           projectId,
           message: `Reaction '${reactionKey}' triggered notification`,
           data: { reactionKey },
+          timestamp: eventContext?.timestamp,
+          idempotencyKey: eventContext?.idempotencyKey,
         });
         await notifyHuman(event, reactionConfig.priority ?? "info", pollStats);
         return {
@@ -730,6 +843,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           projectId,
           message: `Reaction '${reactionKey}' triggered auto-merge`,
           data: { reactionKey },
+          timestamp: eventContext?.timestamp,
+          idempotencyKey: eventContext?.idempotencyKey,
         });
         await notifyHuman(event, "action", pollStats);
         return {
@@ -905,12 +1020,22 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           reactionConfig.action &&
           (reactionConfig.auto !== false || reactionConfig.action === "notify")
         ) {
+          const timestamp = new Date();
           const result = await executeReaction(
             session.id,
             session.projectId,
             humanReactionKey,
             reactionConfig,
             pollStats,
+            {
+              timestamp,
+              idempotencyKey: createScopedIdempotencyKey({
+                sessionId: session.id,
+                scope: humanReactionKey,
+                parts: [pendingFingerprint],
+                timestamp,
+              }),
+            },
           );
           if (result.success) {
             updateSessionMetadata(session, {
@@ -949,12 +1074,22 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           reactionConfig.action &&
           (reactionConfig.auto !== false || reactionConfig.action === "notify")
         ) {
+          const timestamp = new Date();
           const result = await executeReaction(
             session.id,
             session.projectId,
             automatedReactionKey,
             reactionConfig,
             pollStats,
+            {
+              timestamp,
+              idempotencyKey: createScopedIdempotencyKey({
+                sessionId: session.id,
+                scope: automatedReactionKey,
+                parts: [automatedFingerprint],
+                timestamp,
+              }),
+            },
           );
           if (result.success) {
             updateSessionMetadata(session, {
@@ -984,6 +1119,18 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         priority,
         eventType: event.type,
         reason: "no_notifiers_configured",
+      });
+      return;
+    }
+
+    if (!reserveEmission(event.idempotencyKey, event.timestamp.getTime())) {
+      logLifecycle("info", "notification.deduplicated", {
+        pollId: pollStats?.pollId,
+        projectId: event.projectId,
+        sessionId: event.sessionId,
+        priority,
+        eventType: event.type,
+        idempotencyKey: event.idempotencyKey,
       });
       return;
     }
@@ -1085,6 +1232,14 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
       // Handle transition: notify humans and/or trigger reactions
       if (eventType) {
+        const transitionTimestamp = new Date();
+        const transitionIdempotencyKey = createTransitionIdempotencyKey({
+          sessionId: session.id,
+          transition: eventType,
+          oldStatus,
+          newStatus,
+          timestamp: transitionTimestamp,
+        });
         let reactionHandledNotify = false;
 
         if (reactionKey) {
@@ -1099,6 +1254,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
                 reactionKey,
                 reactionConfig,
                 pollStats,
+                {
+                  timestamp: transitionTimestamp,
+                  idempotencyKey: transitionIdempotencyKey,
+                },
               );
               transitionReaction = { key: reactionKey, result: reactionResult };
               // Reaction is handling this event — suppress immediate human notification.
@@ -1120,6 +1279,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             projectId: session.projectId,
             message: `${session.id}: ${oldStatus} → ${newStatus}`,
             data: { oldStatus, newStatus },
+            timestamp: transitionTimestamp,
+            idempotencyKey: transitionIdempotencyKey,
           });
           await notifyHuman(event, priority, pollStats);
         }
@@ -1143,6 +1304,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       return;
     }
     polling = true;
+    pruneRecentEmissions();
     const pollStats = createPollStats();
 
     logLifecycle("info", "poll.start", {
@@ -1216,12 +1378,22 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           const reactionConfig = config.reactions[reactionKey];
           if (reactionConfig && reactionConfig.action) {
             if (reactionConfig.auto !== false || reactionConfig.action === "notify") {
+              const timestamp = new Date();
               await executeReaction(
                 "system",
                 "all",
                 reactionKey,
                 reactionConfig as ReactionConfig,
                 pollStats,
+                {
+                  timestamp,
+                  idempotencyKey: createScopedIdempotencyKey({
+                    sessionId: "system",
+                    scope: reactionKey,
+                    parts: ["all_complete"],
+                    timestamp,
+                  }),
+                },
               );
             }
           }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -764,6 +764,7 @@ export type EventType =
 /** An event emitted by the orchestrator */
 export interface OrchestratorEvent {
   id: string;
+  idempotencyKey: string;
   type: EventType;
   priority: EventPriority;
   sessionId: SessionId;

--- a/packages/integration-tests/src/helpers/event-factory.ts
+++ b/packages/integration-tests/src/helpers/event-factory.ts
@@ -14,6 +14,7 @@ import type {
 export function makeEvent(overrides: Partial<OrchestratorEvent> = {}): OrchestratorEvent {
   return {
     id: "evt-test-1",
+    idempotencyKey: "evt-test-1-key",
     type: "session.spawned" as EventType,
     priority: "info" as EventPriority,
     sessionId: "app-1",

--- a/packages/integration-tests/src/notifier-webhook.integration.test.ts
+++ b/packages/integration-tests/src/notifier-webhook.integration.test.ts
@@ -37,6 +37,7 @@ describe("notifier-webhook integration", () => {
       const body = JSON.parse(fetchMock.mock.calls[0][1].body);
       expect(body.type).toBe("notification");
       expect(body.event.id).toBe("evt-test-1");
+      expect(body.event.idempotencyKey).toBe("evt-test-1-key");
       expect(body.event.type).toBe("ci.failing");
       expect(body.event.priority).toBe("action");
       expect(body.event.sessionId).toBe("app-1");

--- a/packages/plugins/notifier-composio/src/index.test.ts
+++ b/packages/plugins/notifier-composio/src/index.test.ts
@@ -5,6 +5,7 @@ import { manifest, create } from "./index.js";
 function makeEvent(overrides: Partial<OrchestratorEvent> = {}): OrchestratorEvent {
   return {
     id: "evt-1",
+    idempotencyKey: "evt-1-key",
     type: "session.spawned",
     priority: "info",
     sessionId: "app-1",

--- a/packages/plugins/notifier-desktop/src/index.test.ts
+++ b/packages/plugins/notifier-desktop/src/index.test.ts
@@ -21,6 +21,7 @@ const mockPlatform = platform as unknown as Mock;
 function makeEvent(overrides: Partial<OrchestratorEvent> = {}): OrchestratorEvent {
   return {
     id: "evt-1",
+    idempotencyKey: "evt-1-key",
     type: "session.spawned",
     priority: "info",
     sessionId: "app-1",

--- a/packages/plugins/notifier-slack/src/index.test.ts
+++ b/packages/plugins/notifier-slack/src/index.test.ts
@@ -5,6 +5,7 @@ import { manifest, create } from "./index.js";
 function makeEvent(overrides: Partial<OrchestratorEvent> = {}): OrchestratorEvent {
   return {
     id: "evt-1",
+    idempotencyKey: "evt-1-key",
     type: "session.spawned",
     priority: "info",
     sessionId: "app-1",

--- a/packages/plugins/notifier-webhook/src/index.test.ts
+++ b/packages/plugins/notifier-webhook/src/index.test.ts
@@ -5,6 +5,7 @@ import { manifest, create } from "./index.js";
 function makeEvent(overrides: Partial<OrchestratorEvent> = {}): OrchestratorEvent {
   return {
     id: "evt-1",
+    idempotencyKey: "evt-1-key",
     type: "ci.failing",
     priority: "action",
     sessionId: "app-1",
@@ -88,6 +89,7 @@ describe("notifier-webhook", () => {
       const body = JSON.parse(opts.body);
       expect(body.type).toBe("notification");
       expect(body.event.id).toBe("evt-1");
+      expect(body.event.idempotencyKey).toBe("evt-1-key");
       expect(body.event.sessionId).toBe("app-1");
       expect(body.event.type).toBe("ci.failing");
     });

--- a/packages/plugins/notifier-webhook/src/index.ts
+++ b/packages/plugins/notifier-webhook/src/index.ts
@@ -18,6 +18,7 @@ interface WebhookPayload {
   type: "notification" | "notification_with_actions" | "message";
   event?: {
     id: string;
+    idempotencyKey: string;
     type: string;
     priority: string;
     sessionId: string;
@@ -91,6 +92,7 @@ async function postWithRetry(
 function serializeEvent(event: OrchestratorEvent): WebhookPayload["event"] {
   return {
     id: event.id,
+    idempotencyKey: event.idempotencyKey,
     type: event.type,
     priority: event.priority,
     sessionId: event.sessionId,


### PR DESCRIPTION
## Summary
- add deterministic `idempotencyKey` values to orchestrator events and expose them in webhook payloads
- share transition keys with transition-triggered reactions and deduplicate repeated emissions inside the lifecycle manager for 120 seconds
- cover shared-key and duplicate-poll behavior with lifecycle tests and update notifier event fixtures

## Validation
- `pnpm build`
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run lint`

Closes #10
