### PR TITLE
fix: auto-fetch ci failure logs for ci-failed reactions

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1055,6 +1055,281 @@ describe("reactions", () => {
     expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "CI is failing. Fix it.");
   });
 
+  it("auto-fetches CI failure logs when ci-failed has no explicit message", async () => {
+    config.reactions = {
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        retries: 2,
+      },
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getCIFailureLogs: vi.fn().mockResolvedValue("FAIL src/example.test.ts\nExpected true to be false"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(mockSCM.getCIFailureLogs).toHaveBeenCalledWith(session.pr);
+    expect(mockSessionManager.send).toHaveBeenCalledWith(
+      "app-1",
+      "CI failed on your PR. Here are the failure logs:\n\nFAIL src/example.test.ts\nExpected true to be false\n\nPlease fix the failing test(s) and push.",
+    );
+  });
+
+  it("falls back to a generic CI failure message when logs are unavailable", async () => {
+    config.reactions = {
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        retries: 2,
+      },
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getCIFailureLogs: vi.fn().mockResolvedValue(null),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(mockSessionManager.send).toHaveBeenCalledWith(
+      "app-1",
+      "CI has failed on your PR. Please check the CI logs, fix the issue, and push.",
+    );
+  });
+
+  it("re-fires persistent ci_failed reactions after the configured interval", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T12:00:00.000Z"));
+
+    config.reactions = {
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        retries: 3,
+        refireIntervalMs: 120_000,
+      },
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getCIFailureLogs: vi
+        .fn()
+        .mockResolvedValueOnce("first failure")
+        .mockResolvedValueOnce("updated failure"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date("2026-03-09T12:01:59.000Z"));
+    await lm.check("app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date("2026-03-09T12:02:01.000Z"));
+    await lm.check("app-1");
+
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(2);
+    expect(mockSessionManager.send).toHaveBeenNthCalledWith(
+      2,
+      "app-1",
+      "CI failed on your PR. Here are the failure logs:\n\nupdated failure\n\nPlease fix the failing test(s) and push.",
+    );
+  });
+
+  it("escalates persistent ci_failed reactions after retries are exhausted", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T13:00:00.000Z"));
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    config.reactions = {
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        retries: 1,
+        refireIntervalMs: 120_000,
+      },
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getCIFailureLogs: vi.fn().mockResolvedValue("initial failure"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(mockNotifier.notify).not.toHaveBeenCalled();
+
+    vi.setSystemTime(new Date("2026-03-09T13:02:01.000Z"));
+    await lm.check("app-1");
+
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(mockNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(mockNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "reaction.escalated" }),
+    );
+
+    vi.setSystemTime(new Date("2026-03-09T13:04:02.000Z"));
+    await lm.check("app-1");
+
+    expect(mockNotifier.notify).toHaveBeenCalledTimes(1);
+  });
+
   it("does not trigger reaction when auto=false", async () => {
     config.reactions = {
       "ci-failed": {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -28,6 +28,7 @@ const ReactionConfigSchema = z.object({
   message: z.string().optional(),
   priority: z.enum(["urgent", "action", "warning", "info"]).optional(),
   retries: z.number().optional(),
+  refireIntervalMs: z.number().nonnegative().optional(),
   escalateAfter: z.union([z.number(), z.string()]).optional(),
   threshold: z.string().optional(),
   includeSummary: z.boolean().optional(),
@@ -228,9 +229,8 @@ function applyDefaultReactions(config: OrchestratorConfig): OrchestratorConfig {
     "ci-failed": {
       auto: true,
       action: "send-to-agent",
-      message:
-        "CI is failing on your PR. Run `gh pr checks` to see the failures, fix them, and push.",
       retries: 2,
+      refireIntervalMs: 120_000,
       escalateAfter: 2,
     },
     "changes-requested": {
@@ -238,6 +238,7 @@ function applyDefaultReactions(config: OrchestratorConfig): OrchestratorConfig {
       action: "send-to-agent",
       message:
         "There are review comments on your PR. Check with `gh pr view --comments` and `gh api` for inline comments. Address each one, push fixes, and reply.",
+      refireIntervalMs: 300_000,
       escalateAfter: "30m",
     },
     "bugbot-comments": {
@@ -262,6 +263,7 @@ function applyDefaultReactions(config: OrchestratorConfig): OrchestratorConfig {
       auto: true,
       action: "notify",
       priority: "urgent",
+      refireIntervalMs: 300_000,
       threshold: "10m",
     },
     "agent-needs-input": {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -169,6 +169,8 @@ export interface LifecycleManagerDeps {
 interface ReactionTracker {
   attempts: number;
   firstTriggered: Date;
+  lastReactionFiredAtMs: number;
+  escalatedAtMs?: number;
 }
 
 interface LifecyclePollStats {
@@ -263,6 +265,8 @@ function createPollStats(): LifecyclePollStats {
 }
 
 const OPEN_PR_STATUS_POLL_INTERVAL_MS = 60_000;
+const DEFAULT_CI_REACTION_REFIRE_INTERVAL_MS = 120_000;
+const DEFAULT_REACTION_REFIRE_INTERVAL_MS = 300_000;
 
 interface OpenPREvaluation {
   status: SessionStatus;
@@ -291,6 +295,34 @@ function shouldOverridePreservedPRStatus(status: SessionStatus): boolean {
   );
 }
 
+function getPersistentReactionKey(status: SessionStatus): string | null {
+  switch (status) {
+    case SESSION_STATUS.CI_FAILED:
+      return "ci-failed";
+    case SESSION_STATUS.CHANGES_REQUESTED:
+      return "changes-requested";
+    case SESSION_STATUS.STUCK:
+      return "agent-stuck";
+    default:
+      return null;
+  }
+}
+
+function getReactionRefireIntervalMs(
+  reactionKey: string,
+  reactionConfig: ReactionConfig,
+): number {
+  if (typeof reactionConfig.refireIntervalMs === "number") {
+    return reactionConfig.refireIntervalMs;
+  }
+
+  if (reactionKey === "ci-failed") {
+    return DEFAULT_CI_REACTION_REFIRE_INTERVAL_MS;
+  }
+
+  return DEFAULT_REACTION_REFIRE_INTERVAL_MS;
+}
+
 /** Create a LifecycleManager instance. */
 export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleManager {
   const { config, registry, sessionManager, projectId: scopedProjectId } = deps;
@@ -300,6 +332,116 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let polling = false; // re-entrancy guard
   let allCompleteEmitted = false; // guard against repeated all_complete
+
+  function getOrCreateReactionTracker(sessionId: SessionId, reactionKey: string): ReactionTracker {
+    const trackerKey = `${sessionId}:${reactionKey}`;
+    let tracker = reactionTrackers.get(trackerKey);
+
+    if (!tracker) {
+      tracker = {
+        attempts: 0,
+        firstTriggered: new Date(),
+        lastReactionFiredAtMs: 0,
+      };
+      reactionTrackers.set(trackerKey, tracker);
+    }
+
+    return tracker;
+  }
+
+  async function buildSendToAgentMessage(
+    sessionId: SessionId,
+    projectId: string,
+    reactionKey: string,
+    reactionConfig: ReactionConfig,
+    pollStats?: LifecyclePollStats,
+    session?: Session,
+  ): Promise<string | null> {
+    if (reactionConfig.message) {
+      return reactionConfig.message;
+    }
+
+    if (reactionKey !== "ci-failed") {
+      return null;
+    }
+
+    const fallbackMessage =
+      "CI has failed on your PR. Please check the CI logs, fix the issue, and push.";
+    const currentSession = session ?? (await sessionManager.get(sessionId));
+
+    if (!currentSession?.pr) {
+      return fallbackMessage;
+    }
+
+    const project = config.projects[currentSession.projectId] ?? config.projects[projectId];
+    if (!project?.scm) {
+      return fallbackMessage;
+    }
+
+    const scm = registry.get<SCM>("scm", project.scm.plugin);
+    if (!scm?.getCIFailureLogs) {
+      return fallbackMessage;
+    }
+
+    try {
+      const logs = await scm.getCIFailureLogs(currentSession.pr);
+      if (!logs) {
+        return fallbackMessage;
+      }
+
+      return `CI failed on your PR. Here are the failure logs:\n\n${logs}\n\nPlease fix the failing test(s) and push.`;
+    } catch (error) {
+      incrementPollError(pollStats);
+      logLifecycle("error", "reaction.ci_logs.failed", {
+        pollId: pollStats?.pollId,
+        projectId: currentSession.projectId,
+        sessionId,
+        reactionKey,
+        pr: currentSession.pr,
+        error,
+      });
+      return fallbackMessage;
+    }
+  }
+
+  async function maybeRefirePersistentReaction(
+    session: Session,
+    status: SessionStatus,
+    pollStats?: LifecyclePollStats,
+  ): Promise<void> {
+    const reactionKey = getPersistentReactionKey(status);
+    if (!reactionKey) {
+      return;
+    }
+
+    const reactionConfig = getReactionConfigForSession(session, reactionKey);
+    if (!reactionConfig?.action) {
+      return;
+    }
+
+    if (reactionConfig.auto === false && reactionConfig.action !== "notify") {
+      return;
+    }
+
+    const tracker = reactionTrackers.get(`${session.id}:${reactionKey}`);
+    if (!tracker || tracker.escalatedAtMs !== undefined) {
+      return;
+    }
+
+    const refireIntervalMs = getReactionRefireIntervalMs(reactionKey, reactionConfig);
+    if (Date.now() - tracker.lastReactionFiredAtMs < refireIntervalMs) {
+      return;
+    }
+
+    await executeReaction(
+      session.id,
+      session.projectId,
+      reactionKey,
+      reactionConfig,
+      pollStats,
+      session,
+    );
+  }
 
   /** Check if idle time exceeds the agent-stuck threshold. */
   function isIdleBeyondThreshold(session: Session, idleTimestamp: Date): boolean {
@@ -605,17 +747,14 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     reactionKey: string,
     reactionConfig: ReactionConfig,
     pollStats?: LifecyclePollStats,
+    session?: Session,
   ): Promise<ReactionResult> {
-    const trackerKey = `${sessionId}:${reactionKey}`;
-    let tracker = reactionTrackers.get(trackerKey);
-
-    if (!tracker) {
-      tracker = { attempts: 0, firstTriggered: new Date() };
-      reactionTrackers.set(trackerKey, tracker);
-    }
+    const tracker = getOrCreateReactionTracker(sessionId, reactionKey);
+    const nowMs = Date.now();
 
     // Increment attempts before checking escalation
     tracker.attempts++;
+    tracker.lastReactionFiredAtMs = nowMs;
 
     // Check if we should escalate
     const maxRetries = reactionConfig.retries ?? Infinity;
@@ -638,6 +777,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
 
     if (shouldEscalate) {
+      tracker.escalatedAtMs = nowMs;
+
       // Escalate to human
       const event = createEvent("reaction.escalated", {
         sessionId,
@@ -666,9 +807,18 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     switch (action) {
       case "send-to-agent": {
-        if (reactionConfig.message) {
+        const message = await buildSendToAgentMessage(
+          sessionId,
+          projectId,
+          reactionKey,
+          reactionConfig,
+          pollStats,
+          session,
+        );
+
+        if (message) {
           try {
-            await sessionManager.send(sessionId, reactionConfig.message);
+            await sessionManager.send(sessionId, message);
             logLifecycle("info", "reaction.sent_to_agent", {
               pollId: pollStats?.pollId,
               projectId,
@@ -681,7 +831,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
               reactionType: reactionKey,
               success: true,
               action: "send-to-agent",
-              message: reactionConfig.message,
+              message,
               escalated: false,
             };
           } catch (error) {
@@ -1130,6 +1280,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
 
     await maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction, pollStats);
+
+    if (newStatus === oldStatus) {
+      await maybeRefirePersistentReaction(session, newStatus, pollStats);
+    }
   }
 
   /** Run one polling cycle across all sessions. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -550,6 +550,9 @@ export interface SCM {
   /** Get overall CI summary */
   getCISummary(pr: PRInfo): Promise<CIStatus>;
 
+  /** Get CI failure log output for a PR (truncated). Optional. */
+  getCIFailureLogs?(pr: PRInfo): Promise<string | null>;
+
   // --- Review Tracking ---
 
   /** Get all reviews on a PR */
@@ -793,6 +796,9 @@ export interface ReactionConfig {
 
   /** How many times to retry send-to-agent before escalating */
   retries?: number;
+
+  /** How long to wait before re-firing for a persistent actionable state */
+  refireIntervalMs?: number;
 
   /** Escalate to human notification after this many failures or this duration */
   escalateAfter?: number | string;

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -87,6 +87,32 @@ function parseDate(val: string | undefined | null): Date {
   return isNaN(d.getTime()) ? new Date(0) : d;
 }
 
+function extractRunIdFromUrl(url: string | undefined): string | null {
+  if (!url) return null;
+
+  const pattern = /\/runs\/(\d+)(?:\/|$)/;
+  const fallbackMatch = url.match(pattern)?.[1] ?? null;
+
+  try {
+    const parsed = new URL(url);
+    const match = parsed.pathname.match(pattern);
+    if (match?.[1]) {
+      return match[1];
+    }
+  } catch {
+    return fallbackMatch;
+  }
+
+  return fallbackMatch;
+}
+
+function truncateLogOutput(logs: string, maxLines: number): string | null {
+  const trimmed = logs.trim();
+  if (!trimmed) return null;
+
+  return trimmed.split(/\r?\n/).slice(-maxLines).join("\n");
+}
+
 function isUnsupportedPrChecksJsonError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   return /pr checks/i.test(err.message) && /unknown json field/i.test(err.message);
@@ -404,6 +430,38 @@ function createGitHubSCM(): SCM {
         // Do NOT silently return [] — that causes a fail-open where CI
         // appears healthy when we simply failed to fetch check status.
         throw new Error("Failed to fetch CI checks", { cause: err });
+      }
+    },
+
+    async getCIFailureLogs(pr: PRInfo): Promise<string | null> {
+      try {
+        const failedRunIds = (await this.getCIChecks(pr))
+          .filter((check) => check.status === "failed")
+          .map((check) => extractRunIdFromUrl(check.url))
+          .filter((runId): runId is string => runId !== null);
+
+        for (const runId of failedRunIds) {
+          try {
+            const logs = await gh([
+              "run",
+              "view",
+              runId,
+              "--repo",
+              repoFlag(pr),
+              "--log-failed",
+            ]);
+            const truncatedLogs = truncateLogOutput(logs, 80);
+            if (truncatedLogs) {
+              return truncatedLogs;
+            }
+          } catch {
+            continue;
+          }
+        }
+
+        return null;
+      } catch {
+        return null;
       }
     },
 

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -63,6 +63,10 @@ function mockGh(result: unknown) {
   ghMock.mockResolvedValueOnce({ stdout: JSON.stringify(result) });
 }
 
+function mockGhStdout(stdout: string) {
+  ghMock.mockResolvedValueOnce({ stdout });
+}
+
 function mockGhError(msg = "Command failed") {
   ghMock.mockRejectedValueOnce(new Error(msg));
 }
@@ -404,6 +408,63 @@ describe("scm-github plugin", () => {
       expect(checks[0]).toMatchObject({ name: "Test", status: "passed", url: "https://ci/test" });
       expect(checks[1]).toMatchObject({ name: "Lint", status: "pending", url: "https://ci/lint" });
       expect(ghMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("getCIFailureLogs", () => {
+    it("returns the last 80 lines from the first failed GitHub Actions run", async () => {
+      mockGh([
+        {
+          name: "build",
+          state: "FAILURE",
+          link: "https://github.com/acme/repo/actions/runs/123456789/job/1",
+          startedAt: "2025-01-01T00:00:00Z",
+          completedAt: "2025-01-01T00:05:00Z",
+        },
+      ]);
+      mockGhStdout(
+        Array.from({ length: 100 }, (_, index) => `line ${index + 1}`).join("\n"),
+      );
+
+      await expect(scm.getCIFailureLogs?.(pr)).resolves.toBe(
+        Array.from({ length: 80 }, (_, index) => `line ${index + 21}`).join("\n"),
+      );
+      expect(ghMock).toHaveBeenNthCalledWith(
+        2,
+        "gh",
+        ["run", "view", "123456789", "--repo", "acme/repo", "--log-failed"],
+        expect.any(Object),
+      );
+    });
+
+    it("returns null when there is no failed check with a GitHub Actions run URL", async () => {
+      mockGh([
+        {
+          name: "build",
+          state: "FAILURE",
+          link: "https://ci.example.com/build/42",
+          startedAt: "2025-01-01T00:00:00Z",
+          completedAt: "2025-01-01T00:05:00Z",
+        },
+      ]);
+
+      await expect(scm.getCIFailureLogs?.(pr)).resolves.toBeNull();
+      expect(ghMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns null when fetching the failed run logs fails", async () => {
+      mockGh([
+        {
+          name: "build",
+          state: "FAILURE",
+          link: "https://github.com/acme/repo/runs/123456789?check_suite_focus=true",
+          startedAt: "2025-01-01T00:00:00Z",
+          completedAt: "2025-01-01T00:05:00Z",
+        },
+      ]);
+      mockGhError("run logs unavailable");
+
+      await expect(scm.getCIFailureLogs?.(pr)).resolves.toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- add CI failure log retrieval to the SCM interface and GitHub SCM plugin
- auto-compose ci-failed agent messages when no static message is configured
- re-fire persistent actionable reactions on an interval and escalate after retries are exhausted
- cover the new CI log and refire behavior with unit tests

## Validation
- pnpm run typecheck
- pnpm test
- pnpm run lint

Closes #12
