### PR TITLE
feat: capture subscription usage dials from agent streams

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -301,6 +301,9 @@ export interface Agent {
   /** Extract information from agent's internal data (summary, cost, session ID) */
   getSessionInfo(session: Session): Promise<AgentSessionInfo | null>;
 
+  /** Optional: extract normalized subscription/rate-limit usage for dashboard dials */
+  getUsageSnapshot?(session: Session): Promise<UsageSnapshot | null>;
+
   /**
    * Optional: get a launch command that resumes a previous session.
    * Returns null if no previous session is found (caller falls back to getLaunchCommand).
@@ -384,6 +387,41 @@ export interface CostEstimate {
   inputTokens: number;
   outputTokens: number;
   estimatedCostUsd: number;
+}
+
+export type UsageProvider = "codex" | "claude-code";
+
+export type UsageDialKind = "percent_used" | "percent_remaining" | "absolute";
+
+export type UsageDialStatus = "available" | "unavailable" | "unlimited";
+
+export interface UsageDial {
+  /** Stable dial identifier for merging/sorting UI state */
+  id: string;
+  /** User-facing dial label */
+  label: string;
+  /** How the numeric value should be interpreted */
+  kind: UsageDialKind;
+  /** Dial status when live data is or isn't available */
+  status: UsageDialStatus;
+  /** Raw numeric value (0-100 for percentage dials, absolute for counters) */
+  value: number | null;
+  /** Optional max value used to render gauge progress */
+  maxValue?: number | null;
+  /** Pre-formatted display value for UI rendering */
+  displayValue: string;
+  /** Optional reset timestamp as an ISO string */
+  resetsAt?: string | null;
+}
+
+export interface UsageSnapshot {
+  provider: UsageProvider;
+  /** Human-readable plan or subscription label, when known */
+  plan?: string | null;
+  /** When this snapshot was captured, as an ISO timestamp */
+  capturedAt: string;
+  /** Provider-specific dials */
+  dials: UsageDial[];
 }
 
 // =============================================================================

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -670,3 +670,39 @@ describe("getSessionInfo", () => {
     });
   });
 });
+
+// =========================================================================
+// getUsageSnapshot — subscription dials
+// =========================================================================
+describe("getUsageSnapshot", () => {
+  const agent = create();
+
+  it("returns current-session and weekly usage dials from rate_limit_event lines", async () => {
+    const jsonl = [
+      '{"type":"user","message":{"content":"hi"}}',
+      '{"timestamp":"2026-03-10T12:00:00.000Z","type":"rate_limit_event","rate_limit_info":{"rateLimitType":"five_hour","utilization":0.25,"resetsAt":"2026-03-10T15:00:00.000Z"}}',
+      '{"timestamp":"2026-03-10T12:00:01.000Z","type":"rate_limit_event","rate_limit_info":{"rateLimitType":"seven_day","utilization":0.6,"resetsAt":"2026-03-11T08:00:00.000Z"}}',
+    ].join("\n");
+
+    mockJsonlFiles(jsonl);
+
+    const snapshot = await agent.getUsageSnapshot!(makeSession());
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.provider).toBe("claude-code");
+    expect(snapshot?.dials.map((dial) => dial.id)).toEqual([
+      "claude-current-session",
+      "claude-weekly-all-models",
+    ]);
+    expect(snapshot?.dials.map((dial) => dial.displayValue)).toEqual(["25%", "60%"]);
+    expect(snapshot?.dials.map((dial) => dial.resetsAt)).toEqual([
+      "2026-03-10T15:00:00.000Z",
+      "2026-03-11T08:00:00.000Z",
+    ]);
+  });
+
+  it("returns null when no rate_limit_event lines exist", async () => {
+    mockJsonlFiles('{"type":"assistant","message":{"content":"done"}}');
+    expect(await agent.getUsageSnapshot!(makeSession())).toBeNull();
+  });
+});

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -12,6 +12,8 @@ import {
   type ProjectConfig,
   type RuntimeHandle,
   type Session,
+  type UsageDial,
+  type UsageSnapshot,
   type WorkspaceHooksConfig,
 } from "@composio/ao-core";
 import { execFile } from "node:child_process";
@@ -240,6 +242,7 @@ async function findLatestSessionFile(projectDir: string): Promise<string | null>
 }
 
 interface JsonlLine {
+  timestamp?: string;
   type?: string;
   summary?: string;
   message?: { content?: string; role?: string };
@@ -254,6 +257,19 @@ interface JsonlLine {
   inputTokens?: number;
   outputTokens?: number;
   estimatedCostUsd?: number;
+  rate_limit_info?: ClaudeRateLimitInfo;
+}
+
+interface ClaudeRateLimitInfo {
+  status?: string;
+  resetsAt?: string | null;
+  rateLimitType?: string;
+  utilization?: number;
+  overageStatus?: string;
+  overageResetsAt?: string | null;
+  overageDisabledReason?: string | null;
+  isUsingOverage?: boolean;
+  surpassedThreshold?: boolean;
 }
 
 /**
@@ -389,6 +405,97 @@ function extractCost(lines: JsonlLine[]): CostEstimate | undefined {
   }
 
   return { inputTokens, outputTokens, estimatedCostUsd: totalCost };
+}
+
+function normalizeClaudePercent(value: number | undefined): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+
+  const percent = value <= 1 ? value * 100 : value;
+  return Math.min(100, Math.max(0, percent));
+}
+
+function formatClaudePercent(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded}%` : `${rounded.toFixed(1)}%`;
+}
+
+function createClaudeUsageDial(
+  id: string,
+  label: string,
+  info: ClaudeRateLimitInfo,
+): UsageDial | null {
+  const percent = normalizeClaudePercent(info.utilization);
+  if (percent === null) return null;
+
+  return {
+    id,
+    label,
+    kind: "percent_used",
+    status: "available",
+    value: percent,
+    maxValue: 100,
+    displayValue: formatClaudePercent(percent),
+    resetsAt: info.resetsAt ?? null,
+  };
+}
+
+function extractUsageSnapshot(lines: JsonlLine[]): UsageSnapshot | null {
+  let currentSessionInfo: ClaudeRateLimitInfo | null = null;
+  let weeklyInfo: ClaudeRateLimitInfo | null = null;
+  let capturedAt: string | null = null;
+
+  for (const line of lines) {
+    if (line.type !== "rate_limit_event" || !line.rate_limit_info) continue;
+
+    capturedAt = typeof line.timestamp === "string" ? line.timestamp : capturedAt;
+    const info = line.rate_limit_info;
+    switch (info.rateLimitType) {
+      case "five_hour":
+        currentSessionInfo = info;
+        break;
+      case "seven_day":
+        weeklyInfo = info;
+        break;
+      case "seven_day_opus":
+      case "seven_day_sonnet":
+        if (!weeklyInfo) {
+          weeklyInfo = info;
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  const dials = [
+    currentSessionInfo
+      ? createClaudeUsageDial(
+          "claude-current-session",
+          "Current session usage",
+          currentSessionInfo,
+        )
+      : null,
+    weeklyInfo
+      ? createClaudeUsageDial(
+          "claude-weekly-all-models",
+          "Weekly limits - All models",
+          weeklyInfo,
+        )
+      : null,
+  ].filter((dial): dial is UsageDial => dial !== null);
+
+  if (dials.length === 0) {
+    return null;
+  }
+
+  return {
+    provider: "claude-code",
+    plan: null,
+    capturedAt: capturedAt ?? new Date().toISOString(),
+    dials,
+  };
 }
 
 // =============================================================================
@@ -784,6 +891,21 @@ function createClaudeCodeAgent(): Agent {
         agentSessionId,
         cost: extractCost(lines),
       };
+    },
+
+    async getUsageSnapshot(session: Session): Promise<UsageSnapshot | null> {
+      if (!session.workspacePath) return null;
+
+      const projectPath = toClaudeProjectPath(session.workspacePath);
+      const projectDir = join(homedir(), ".claude", "projects", projectPath);
+
+      const sessionFile = await findLatestSessionFile(projectDir);
+      if (!sessionFile) return null;
+
+      const lines = await parseJsonlFileTail(sessionFile);
+      if (lines.length === 0) return null;
+
+      return extractUsageSnapshot(lines);
     },
 
     async getRestoreCommand(session: Session, project: ProjectConfig): Promise<string | null> {

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -937,6 +937,116 @@ describe("getSessionInfo", () => {
 });
 
 // =========================================================================
+// getUsageSnapshot — subscription dials
+// =========================================================================
+describe("getUsageSnapshot", () => {
+  const agent = create();
+
+  function jsonl(...lines: Record<string, unknown>[]): string {
+    return lines.map((line) => JSON.stringify(line)).join("\n") + "\n";
+  }
+
+  it("returns normalized Codex usage dials from token_count payload events", async () => {
+    const sessionContent = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "gpt-5-codex" },
+      {
+        timestamp: "2026-03-10T12:00:00.000Z",
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: null,
+          rate_limits: {
+            limit_id: "codex",
+            primary: { used_percent: 8, window_minutes: 300, resets_at: 1771803416 },
+            secondary: { used_percent: 12, window_minutes: 10080, resets_at: 1771876568 },
+            credits: { has_credits: true, unlimited: false, balance: "685.6850000000" },
+            plan_type: "pro",
+          },
+        },
+      },
+      {
+        timestamp: "2026-03-10T12:00:01.000Z",
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: null,
+          rate_limits: {
+            limit_id: "codex_bengalfox",
+            limit_name: "GPT-5.3-Codex-Spark",
+            primary: { used_percent: 0, window_minutes: 300, resets_at: 1771806051 },
+            secondary: { used_percent: 2, window_minutes: 10080, resets_at: 1772392851 },
+          },
+        },
+      },
+      {
+        timestamp: "2026-03-10T12:00:02.000Z",
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: null,
+          rate_limits: {
+            limit_id: "codex_review",
+            limit_name: "Code review",
+            primary: { used_percent: 30, window_minutes: 10080, resets_at: 1772392851 },
+          },
+        },
+      },
+    );
+
+    mockReaddir.mockResolvedValue(["rollout-123.jsonl"]);
+    setupMockOpen(sessionContent);
+    setupMockStream(sessionContent);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const snapshot = await agent.getUsageSnapshot!(makeSession({ workspacePath: "/workspace/test" }));
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.provider).toBe("codex");
+    expect(snapshot?.dials.map((dial) => dial.id)).toEqual([
+      "codex-5h",
+      "codex-weekly",
+      "codex-spark-5h",
+      "codex-spark-weekly",
+      "codex-code-review",
+      "codex-credits",
+    ]);
+    expect(snapshot?.dials.map((dial) => dial.displayValue)).toEqual([
+      "92%",
+      "88%",
+      "100%",
+      "98%",
+      "70%",
+      "685",
+    ]);
+  });
+
+  it("returns null when no rate-limit payloads are present", async () => {
+    const sessionContent = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "gpt-5-codex" },
+      {
+        timestamp: "2026-03-10T12:00:00.000Z",
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: {
+            total_token_usage: { input_tokens: 1000, output_tokens: 250, total_tokens: 1250 },
+          },
+          rate_limits: null,
+        },
+      },
+    );
+
+    mockReaddir.mockResolvedValue(["rollout-456.jsonl"]);
+    setupMockOpen(sessionContent);
+    setupMockStream(sessionContent);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const snapshot = await agent.getUsageSnapshot!(makeSession({ workspacePath: "/workspace/test" }));
+    expect(snapshot).toBeNull();
+  });
+});
+
+// =========================================================================
 // getRestoreCommand — conversation resume
 // =========================================================================
 describe("getRestoreCommand", () => {

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -11,6 +11,8 @@ import {
   type ProjectConfig,
   type RuntimeHandle,
   type Session,
+  type UsageDial,
+  type UsageSnapshot,
   type WorkspaceHooksConfig,
 } from "@composio/ao-core";
 import { execFile } from "node:child_process";
@@ -330,6 +332,7 @@ const CODEX_SESSIONS_DIR = join(homedir(), ".codex", "sessions");
 
 /** Typed representation of a line in a Codex JSONL session file */
 interface CodexJsonlLine {
+  timestamp?: string;
   type?: string;
   cwd?: string;
   model?: string;
@@ -339,13 +342,50 @@ interface CodexJsonlLine {
   content?: string;
   role?: string;
   // event_msg with token_count subtype
-  msg?: {
-    type?: string;
-    input_tokens?: number;
-    output_tokens?: number;
-    cached_tokens?: number;
-    reasoning_tokens?: number;
-  };
+  msg?: CodexEventMessage;
+  payload?: CodexEventMessage;
+}
+
+interface CodexTokenUsageTotals {
+  input_tokens?: number;
+  cached_input_tokens?: number;
+  output_tokens?: number;
+  reasoning_output_tokens?: number;
+  total_tokens?: number;
+}
+
+interface CodexTokenUsageInfo {
+  total_token_usage?: CodexTokenUsageTotals | null;
+  last_token_usage?: CodexTokenUsageTotals | null;
+}
+
+interface CodexCreditsSnapshot {
+  has_credits?: boolean;
+  unlimited?: boolean;
+  balance?: number | string | null;
+}
+
+interface CodexRateLimitWindow {
+  used_percent?: number;
+  window_minutes?: number;
+  resets_at?: number | string | null;
+}
+
+interface CodexRateLimitSnapshot {
+  limit_id?: string;
+  limit_name?: string | null;
+  primary?: CodexRateLimitWindow | null;
+  secondary?: CodexRateLimitWindow | null;
+  credits?: CodexCreditsSnapshot | null;
+  plan_type?: string | null;
+}
+
+interface CodexEventMessage {
+  type?: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  info?: CodexTokenUsageInfo | null;
+  rate_limits?: CodexRateLimitSnapshot | CodexRateLimitSnapshot[] | null;
 }
 
 /**
@@ -471,6 +511,256 @@ interface CodexSessionData {
   threadId: string | null;
   inputTokens: number;
   outputTokens: number;
+  usesCumulativeTotals: boolean;
+  rateLimits: Map<string, CodexRateLimitSnapshot>;
+  credits: CodexCreditsSnapshot | null;
+  plan: string | null;
+  capturedAt: string | null;
+}
+
+function extractTokenUsage(
+  message: CodexEventMessage | null | undefined,
+): { inputTokens: number; outputTokens: number; cumulative: boolean } | null {
+  if (!message || message.type !== "token_count") return null;
+
+  const totalUsage = message.info?.total_token_usage;
+  if (
+    totalUsage &&
+    (typeof totalUsage.input_tokens === "number" || typeof totalUsage.output_tokens === "number")
+  ) {
+    return {
+      inputTokens: totalUsage.input_tokens ?? 0,
+      outputTokens: totalUsage.output_tokens ?? 0,
+      cumulative: true,
+    };
+  }
+
+  const lastUsage = message.info?.last_token_usage;
+  if (
+    lastUsage &&
+    (typeof lastUsage.input_tokens === "number" || typeof lastUsage.output_tokens === "number")
+  ) {
+    return {
+      inputTokens: lastUsage.input_tokens ?? 0,
+      outputTokens: lastUsage.output_tokens ?? 0,
+      cumulative: false,
+    };
+  }
+
+  if (
+    typeof message.input_tokens === "number" ||
+    typeof message.output_tokens === "number"
+  ) {
+    return {
+      inputTokens: message.input_tokens ?? 0,
+      outputTokens: message.output_tokens ?? 0,
+      cumulative: false,
+    };
+  }
+
+  return null;
+}
+
+function asRateLimitSnapshots(
+  rateLimits: CodexEventMessage["rate_limits"],
+): CodexRateLimitSnapshot[] {
+  if (!rateLimits) return [];
+  return Array.isArray(rateLimits) ? rateLimits : [rateLimits];
+}
+
+function normalizeResetTimestamp(resetsAt: number | string | null | undefined): string | null {
+  if (typeof resetsAt === "number" && Number.isFinite(resetsAt)) {
+    const millis = resetsAt > 1_000_000_000_000 ? resetsAt : resetsAt * 1000;
+    return new Date(millis).toISOString();
+  }
+
+  if (typeof resetsAt === "string" && resetsAt.trim().length > 0) {
+    const parsed = new Date(resetsAt);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+  }
+
+  return null;
+}
+
+function normalizeBalance(value: number | string | null | undefined): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function clampPercent(value: number): number {
+  return Math.min(100, Math.max(0, value));
+}
+
+function formatPercent(value: number): string {
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? `${rounded}%` : `${rounded.toFixed(1)}%`;
+}
+
+function formatCredits(balance: number): string {
+  const displayBalance = balance >= 1 ? Math.floor(balance) : balance;
+  return new Intl.NumberFormat("en-US", {
+    maximumFractionDigits: displayBalance < 1 ? 1 : 0,
+    minimumFractionDigits: 0,
+  }).format(displayBalance);
+}
+
+function formatPlanType(planType: string | null): string | null {
+  if (!planType) return null;
+  if (planType.toLowerCase() === "pro") {
+    return "ChatGPT Pro";
+  }
+  return planType;
+}
+
+function createPercentRemainingDial(
+  id: string,
+  label: string,
+  window: CodexRateLimitWindow | null | undefined,
+): UsageDial | null {
+  if (!window || typeof window.used_percent !== "number") return null;
+
+  const remaining = clampPercent(100 - window.used_percent);
+  return {
+    id,
+    label,
+    kind: "percent_remaining",
+    status: "available",
+    value: remaining,
+    maxValue: 100,
+    displayValue: formatPercent(remaining),
+    resetsAt: normalizeResetTimestamp(window.resets_at),
+  };
+}
+
+function buildCodexUsageSnapshot(data: CodexSessionData): UsageSnapshot | null {
+  if (data.rateLimits.size === 0 && !data.credits) {
+    return null;
+  }
+
+  const dials = new Map<string, UsageDial>();
+
+  for (const snapshot of data.rateLimits.values()) {
+    const limitKey = `${snapshot.limit_id ?? ""} ${snapshot.limit_name ?? ""}`.toLowerCase();
+    if (!data.plan && snapshot.plan_type) {
+      data.plan = snapshot.plan_type;
+    }
+    if (!data.credits && snapshot.credits) {
+      data.credits = snapshot.credits;
+    }
+
+    if (/review/.test(limitKey)) {
+      const reviewDial = createPercentRemainingDial(
+        "codex-code-review",
+        "Code review",
+        snapshot.primary,
+      );
+      if (reviewDial) {
+        dials.set(reviewDial.id, reviewDial);
+      }
+      continue;
+    }
+
+    const isSpark =
+      limitKey.includes("bengalfox") || limitKey.includes("spark");
+
+    if (isSpark) {
+      const spark5Hour = createPercentRemainingDial(
+        "codex-spark-5h",
+        "GPT-5.3-Codex-Spark 5 hour usage limit",
+        snapshot.primary,
+      );
+      if (spark5Hour) {
+        dials.set(spark5Hour.id, spark5Hour);
+      }
+
+      const sparkWeekly = createPercentRemainingDial(
+        "codex-spark-weekly",
+        "GPT-5.3-Codex-Spark Weekly usage limit",
+        snapshot.secondary,
+      );
+      if (sparkWeekly) {
+        dials.set(sparkWeekly.id, sparkWeekly);
+      }
+      continue;
+    }
+
+    const fiveHour = createPercentRemainingDial(
+      "codex-5h",
+      "5 hour usage limit",
+      snapshot.primary,
+    );
+    if (fiveHour) {
+      dials.set(fiveHour.id, fiveHour);
+    }
+
+    const weekly = createPercentRemainingDial(
+      "codex-weekly",
+      "Weekly usage limit",
+      snapshot.secondary,
+    );
+    if (weekly) {
+      dials.set(weekly.id, weekly);
+    }
+  }
+
+  if (data.credits?.unlimited) {
+    dials.set("codex-credits", {
+      id: "codex-credits",
+      label: "Credits remaining",
+      kind: "absolute",
+      status: "unlimited",
+      value: null,
+      maxValue: null,
+      displayValue: "Unlimited",
+      resetsAt: null,
+    });
+  } else {
+    const balance = normalizeBalance(data.credits?.balance);
+    if (balance !== null) {
+      dials.set("codex-credits", {
+        id: "codex-credits",
+        label: "Credits remaining",
+        kind: "absolute",
+        status: "available",
+        value: balance,
+        maxValue: null,
+        displayValue: formatCredits(balance),
+        resetsAt: null,
+      });
+    }
+  }
+
+  if (dials.size === 0) {
+    return null;
+  }
+
+  const order = [
+    "codex-5h",
+    "codex-weekly",
+    "codex-spark-5h",
+    "codex-spark-weekly",
+    "codex-code-review",
+    "codex-credits",
+  ];
+
+  return {
+    provider: "codex",
+    plan: formatPlanType(data.plan),
+    capturedAt: data.capturedAt ?? new Date().toISOString(),
+    dials: order
+      .map((id) => dials.get(id))
+      .filter((dial): dial is UsageDial => dial !== undefined),
+  };
 }
 
 /**
@@ -480,7 +770,17 @@ interface CodexSessionData {
  */
 async function streamCodexSessionData(filePath: string): Promise<CodexSessionData | null> {
   try {
-    const data: CodexSessionData = { model: null, threadId: null, inputTokens: 0, outputTokens: 0 };
+    const data: CodexSessionData = {
+      model: null,
+      threadId: null,
+      inputTokens: 0,
+      outputTokens: 0,
+      usesCumulativeTotals: false,
+      rateLimits: new Map(),
+      credits: null,
+      plan: null,
+      capturedAt: null,
+    };
     const rl = createInterface({
       input: createReadStream(filePath, { encoding: "utf-8" }),
       crlfDelay: Infinity,
@@ -497,12 +797,42 @@ async function streamCodexSessionData(filePath: string): Promise<CodexSessionDat
         if (entry.type === "session_meta" && typeof entry.model === "string") {
           data.model = entry.model;
         }
+        if (typeof entry.timestamp === "string" && entry.timestamp) {
+          data.capturedAt = entry.timestamp;
+        }
         if (typeof entry.threadId === "string" && entry.threadId) {
           data.threadId = entry.threadId;
         }
-        if (entry.type === "event_msg" && entry.msg?.type === "token_count") {
-          data.inputTokens += entry.msg.input_tokens ?? 0;
-          data.outputTokens += entry.msg.output_tokens ?? 0;
+
+        if (entry.type !== "event_msg") continue;
+
+        const messages = [entry.msg, entry.payload];
+        for (const message of messages) {
+          const tokenUsage = extractTokenUsage(message);
+          if (tokenUsage) {
+            if (tokenUsage.cumulative) {
+              data.usesCumulativeTotals = true;
+              data.inputTokens = Math.max(data.inputTokens, tokenUsage.inputTokens);
+              data.outputTokens = Math.max(data.outputTokens, tokenUsage.outputTokens);
+            } else if (!data.usesCumulativeTotals) {
+              data.inputTokens += tokenUsage.inputTokens;
+              data.outputTokens += tokenUsage.outputTokens;
+            }
+          }
+
+          for (const snapshot of asRateLimitSnapshots(message?.rate_limits)) {
+            const key =
+              snapshot.limit_id ??
+              snapshot.limit_name ??
+              `limit-${data.rateLimits.size + 1}`;
+            data.rateLimits.set(key, snapshot);
+            if (snapshot.credits) {
+              data.credits = snapshot.credits;
+            }
+            if (snapshot.plan_type) {
+              data.plan = snapshot.plan_type;
+            }
+          }
         }
       } catch {
         // Skip malformed lines
@@ -796,6 +1126,18 @@ function createCodexAgent(): Agent {
         agentSessionId,
         cost,
       };
+    },
+
+    async getUsageSnapshot(session: Session): Promise<UsageSnapshot | null> {
+      if (!session.workspacePath) return null;
+
+      const sessionFile = await findCodexSessionFileCached(session.workspacePath);
+      if (!sessionFile) return null;
+
+      const data = await streamCodexSessionData(sessionFile);
+      if (!data) return null;
+
+      return buildCodexUsageSnapshot(data);
     },
 
     async getRestoreCommand(session: Session, project: ProjectConfig): Promise<string | null> {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@composio/ao-core": "workspace:*",
     "@composio/ao-plugin-agent-claude-code": "workspace:*",
+    "@composio/ao-plugin-agent-codex": "workspace:*",
     "@composio/ao-plugin-agent-opencode": "workspace:*",
     "@composio/ao-plugin-runtime-tmux": "workspace:*",
     "@composio/ao-plugin-scm-github": "workspace:*",

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -3,7 +3,6 @@ import { NextRequest } from "next/server";
 import {
   SessionNotFoundError,
   SessionNotRestorableError,
-  SessionNotFoundError,
   type Session,
   type SessionManager,
   type OrchestratorConfig,
@@ -12,6 +11,37 @@ import {
 } from "@composio/ao-core";
 import * as serialize from "@/lib/serialize";
 import { getSCM } from "@/lib/services";
+
+const { mockGetDashboardUsage, mockGetSessionUsage } = vi.hoisted(() => ({
+  mockGetDashboardUsage: vi.fn(async () => ({
+    updatedAt: "2026-03-10T12:00:00.000Z",
+    snapshots: [
+      {
+        provider: "codex" as const,
+        plan: "ChatGPT Pro",
+        capturedAt: "2026-03-10T12:00:00.000Z",
+        dials: [],
+      },
+      {
+        provider: "claude-code" as const,
+        plan: null,
+        capturedAt: "2026-03-10T12:00:00.000Z",
+        dials: [],
+      },
+    ],
+  })),
+  mockGetSessionUsage: vi.fn(async (session: Session) => ({
+    sessionId: session.id,
+    provider: "claude-code" as const,
+    cost: { inputTokens: 1200, outputTokens: 340, estimatedCostUsd: 0.021 },
+    snapshot: {
+      provider: "claude-code" as const,
+      plan: null,
+      capturedAt: "2026-03-10T12:00:00.000Z",
+      dials: [],
+    },
+  })),
+}));
 
 // ── Mock Data ─────────────────────────────────────────────────────────
 // Provides test sessions covering the key states the dashboard needs.
@@ -159,15 +189,22 @@ vi.mock("@/lib/services", () => ({
   getSCM: vi.fn(() => mockSCM),
 }));
 
+vi.mock("@/lib/usage", () => ({
+  getDashboardUsage: mockGetDashboardUsage,
+  getSessionUsage: mockGetSessionUsage,
+}));
+
 // ── Import routes after mocking ───────────────────────────────────────
 
 import { GET as sessionsGET } from "@/app/api/sessions/route";
+import { GET as usageGET } from "@/app/api/usage/route";
 import { POST as spawnPOST } from "@/app/api/spawn/route";
 import { POST as sendPOST } from "@/app/api/sessions/[id]/send/route";
 import { POST as messagePOST } from "@/app/api/sessions/[id]/message/route";
 import { POST as killPOST } from "@/app/api/sessions/[id]/kill/route";
 import { POST as restorePOST } from "@/app/api/sessions/[id]/restore/route";
 import { POST as remapPOST } from "@/app/api/sessions/[id]/remap/route";
+import { GET as sessionUsageGET } from "@/app/api/sessions/[id]/usage/route";
 import { POST as mergePOST } from "@/app/api/prs/[id]/merge/route";
 import { GET as eventsGET } from "@/app/api/events/route";
 
@@ -186,6 +223,34 @@ beforeEach(() => {
   (mockSessionManager.get as ReturnType<typeof vi.fn>).mockImplementation(
     async (id: string) => testSessions.find((s) => s.id === id) ?? null,
   );
+  mockGetDashboardUsage.mockResolvedValue({
+    updatedAt: "2026-03-10T12:00:00.000Z",
+    snapshots: [
+      {
+        provider: "codex",
+        plan: "ChatGPT Pro",
+        capturedAt: "2026-03-10T12:00:00.000Z",
+        dials: [],
+      },
+      {
+        provider: "claude-code",
+        plan: null,
+        capturedAt: "2026-03-10T12:00:00.000Z",
+        dials: [],
+      },
+    ],
+  });
+  mockGetSessionUsage.mockImplementation(async (session: Session) => ({
+    sessionId: session.id,
+    provider: "claude-code",
+    cost: { inputTokens: 1200, outputTokens: 340, estimatedCostUsd: 0.021 },
+    snapshot: {
+      provider: "claude-code",
+      plan: null,
+      capturedAt: "2026-03-10T12:00:00.000Z",
+      dials: [],
+    },
+  }));
 });
 
 describe("API Routes", () => {
@@ -239,6 +304,42 @@ describe("API Routes", () => {
 
       metadataSpy.mockRestore();
       vi.useRealTimers();
+    });
+  });
+
+  describe("GET /api/usage", () => {
+    it("returns provider snapshots from the usage service", async () => {
+      const res = await usageGET();
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.updatedAt).toBe("2026-03-10T12:00:00.000Z");
+      expect(data.snapshots).toHaveLength(2);
+      expect(data.snapshots[0].provider).toBe("codex");
+      expect(mockGetDashboardUsage).toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /api/sessions/:id/usage", () => {
+    it("returns usage for a known session", async () => {
+      const res = await sessionUsageGET(makeRequest("/api/sessions/backend-3/usage"), {
+        params: Promise.resolve({ id: "backend-3" }),
+      });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.sessionId).toBe("backend-3");
+      expect(data.provider).toBe("claude-code");
+      expect(data.cost.inputTokens).toBe(1200);
+      expect(mockGetSessionUsage).toHaveBeenCalled();
+    });
+
+    it("returns 404 for unknown sessions", async () => {
+      const res = await sessionUsageGET(makeRequest("/api/sessions/missing/usage"), {
+        params: Promise.resolve({ id: "missing" }),
+      });
+
+      expect(res.status).toBe(404);
     });
   });
 

--- a/packages/web/src/app/api/sessions/[id]/usage/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/usage/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { getServices } from "@/lib/services";
+import { getSessionUsage } from "@/lib/usage";
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const { config, registry, sessionManager } = await getServices();
+
+    const session = await sessionManager.get(id);
+    if (!session) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    const usage = await getSessionUsage(session, config, registry);
+    return NextResponse.json(usage);
+  } catch (error) {
+    console.error("Failed to fetch session usage:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/packages/web/src/app/api/usage/route.ts
+++ b/packages/web/src/app/api/usage/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { getServices } from "@/lib/services";
+import { getDashboardUsage } from "@/lib/usage";
+
+export async function GET() {
+  try {
+    const { config, registry, sessionManager } = await getServices();
+    const sessions = await sessionManager.list();
+    const usage = await getDashboardUsage(sessions, config, registry);
+    return NextResponse.json(usage);
+  } catch (error) {
+    console.error("Failed to fetch usage:", error);
+    return NextResponse.json({ error: "Failed to fetch usage" }, { status: 500 });
+  }
+}

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -3,7 +3,12 @@
 import { useEffect, useState, useCallback } from "react";
 import { useParams } from "next/navigation";
 import { SessionDetail } from "@/components/SessionDetail";
-import { type DashboardSession, getAttentionLevel, type AttentionLevel } from "@/lib/types";
+import {
+  type DashboardSession,
+  type SessionUsageResponse,
+  getAttentionLevel,
+  type AttentionLevel,
+} from "@/lib/types";
 import { activityIcon } from "@/lib/activity-icons";
 
 function truncate(s: string, max: number): string {
@@ -46,6 +51,7 @@ export default function SessionPage() {
   const isOrchestrator = id.endsWith("-orchestrator");
 
   const [session, setSession] = useState<DashboardSession | null>(null);
+  const [usage, setUsage] = useState<SessionUsageResponse | null>(null);
   const [zoneCounts, setZoneCounts] = useState<ZoneCounts | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -99,13 +105,27 @@ export default function SessionPage() {
     }
   }, [isOrchestrator]);
 
+  const fetchUsage = useCallback(async () => {
+    if (isOrchestrator) return;
+
+    try {
+      const res = await fetch(`/api/sessions/${encodeURIComponent(id)}/usage`);
+      if (!res.ok) return;
+      const data = (await res.json()) as SessionUsageResponse;
+      setUsage(data);
+    } catch {
+      // Non-critical — the page still works without usage details
+    }
+  }, [id, isOrchestrator]);
+
   // Initial fetch — session first, zone counts after (avoids blocking on slow /api/sessions)
   useEffect(() => {
     fetchSession();
+    void fetchUsage();
     // Delay zone counts so the heavy /api/sessions call doesn't contend with session load
     const t = setTimeout(fetchZoneCounts, 2000);
     return () => clearTimeout(t);
-  }, [fetchSession, fetchZoneCounts]);
+  }, [fetchSession, fetchUsage, fetchZoneCounts]);
 
   // Poll every 5s
   useEffect(() => {
@@ -115,6 +135,13 @@ export default function SessionPage() {
     }, 5000);
     return () => clearInterval(interval);
   }, [fetchSession, fetchZoneCounts]);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      void fetchUsage();
+    }, 60_000);
+    return () => clearInterval(interval);
+  }, [fetchUsage]);
 
   if (loading) {
     return (
@@ -138,6 +165,7 @@ export default function SessionPage() {
   return (
     <SessionDetail
       session={session}
+      usage={usage}
       isOrchestrator={isOrchestrator}
       orchestratorZones={zoneCounts ?? undefined}
     />

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -14,6 +14,7 @@ import { AttentionZone } from "./AttentionZone";
 import { PRTableRow } from "./PRStatus";
 import { DynamicFavicon } from "./DynamicFavicon";
 import { useSessionEvents } from "@/hooks/useSessionEvents";
+import { UsageOverview } from "./UsageOverview";
 
 interface DashboardProps {
   initialSessions: DashboardSession[];
@@ -118,6 +119,8 @@ export function Dashboard({ initialSessions, stats, orchestratorId, projectName 
           </a>
         )}
       </div>
+
+      <UsageOverview />
 
       {/* Rate limit notice */}
       {anyRateLimited && !rateLimitDismissed && (

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -2,12 +2,18 @@
 
 import { useState, useEffect, useRef } from "react";
 import { useSearchParams } from "next/navigation";
-import { type DashboardSession, type DashboardPR, isPRMergeReady } from "@/lib/types";
+import {
+  type DashboardSession,
+  type DashboardPR,
+  type SessionUsageResponse,
+  isPRMergeReady,
+} from "@/lib/types";
 import { CI_STATUS } from "@composio/ao-core/types";
 import { cn } from "@/lib/cn";
 import { CICheckList } from "./CIBadge";
 import { DirectTerminal } from "./DirectTerminal";
 import { ActivityDot } from "./ActivityDot";
+import { SessionUsageCard } from "./UsageDials";
 
 interface OrchestratorZones {
   merge: number;
@@ -20,6 +26,7 @@ interface OrchestratorZones {
 
 interface SessionDetailProps {
   session: DashboardSession;
+  usage?: SessionUsageResponse | null;
   isOrchestrator?: boolean;
   orchestratorZones?: OrchestratorZones;
 }
@@ -191,6 +198,7 @@ function OrchestratorStatusStrip({
 
 export function SessionDetail({
   session,
+  usage = null,
   isOrchestrator = false,
   orchestratorZones,
 }: SessionDetailProps) {
@@ -375,6 +383,10 @@ export function SessionDetail({
             </div>
           </div>
         </div>
+
+        {!isOrchestrator && (
+          <SessionUsageCard cost={usage?.cost ?? null} snapshot={usage?.snapshot ?? null} />
+        )}
 
         {/* ── PR Card ─────────────────────────────────────────────── */}
         {pr && <PRCard pr={pr} sessionId={session.id} />}

--- a/packages/web/src/components/UsageDials.tsx
+++ b/packages/web/src/components/UsageDials.tsx
@@ -1,0 +1,303 @@
+import { cn } from "@/lib/cn";
+import type { CostEstimate, UsageDial, UsageProvider, UsageSnapshot } from "@/lib/types";
+
+interface UsagePanelsProps {
+  snapshots: UsageSnapshot[];
+  compact?: boolean;
+}
+
+interface SessionUsageCardProps {
+  cost: CostEstimate | null;
+  snapshot: UsageSnapshot | null;
+}
+
+const PROVIDER_META: Record<
+  UsageProvider,
+  { title: string; accent: string; glow: string; heading: string }
+> = {
+  codex: {
+    title: "Codex",
+    accent: "var(--color-accent-blue)",
+    glow: "rgba(88,166,255,0.16)",
+    heading: "ChatGPT Pro limits",
+  },
+  "claude-code": {
+    title: "Claude Code",
+    accent: "var(--color-accent-violet)",
+    glow: "rgba(163,113,247,0.16)",
+    heading: "claude.ai subscription",
+  },
+};
+
+function formatResetTime(resetsAt: string | null | undefined): string | null {
+  if (!resetsAt) return null;
+
+  const date = new Date(resetsAt);
+  if (Number.isNaN(date.getTime())) return null;
+
+  const formatted = new Intl.DateTimeFormat(undefined, {
+    weekday: "short",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+
+  return `Resets ${formatted.replace(",", "")}`;
+}
+
+function progressForDial(dial: UsageDial): number | null {
+  if (dial.status === "unavailable") return null;
+  if (dial.status === "unlimited") return 100;
+  if (dial.value === null) return null;
+
+  if (dial.kind === "absolute") {
+    if (typeof dial.maxValue === "number" && dial.maxValue > 0) {
+      return Math.min(100, Math.max(0, (dial.value / dial.maxValue) * 100));
+    }
+    return 100;
+  }
+
+  const maxValue = typeof dial.maxValue === "number" && dial.maxValue > 0 ? dial.maxValue : 100;
+  return Math.min(100, Math.max(0, (dial.value / maxValue) * 100));
+}
+
+function valueClassName(displayValue: string): string {
+  if (displayValue.length >= 9) return "text-[11px]";
+  if (displayValue.length >= 6) return "text-[14px]";
+  return "text-[18px]";
+}
+
+function CircularUsageDial({
+  dial,
+  accent,
+  compact = false,
+}: {
+  dial: UsageDial;
+  accent: string;
+  compact?: boolean;
+}) {
+  const size = compact ? 104 : 116;
+  const strokeWidth = compact ? 8 : 9;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const progress = progressForDial(dial);
+  const dashOffset =
+    progress === null ? circumference : circumference - (progress / 100) * circumference;
+  const resetLabel = formatResetTime(dial.resetsAt);
+  const helperText =
+    dial.status === "unavailable"
+      ? "No live data yet"
+      : resetLabel ?? (dial.kind === "absolute" ? "Live balance" : "Live usage");
+
+  return (
+    <div
+      className={cn(
+        "rounded-[14px] border border-[var(--color-border-subtle)] bg-[rgba(255,255,255,0.02)] px-3 py-3",
+        compact ? "min-w-[150px]" : "min-w-[168px]",
+      )}
+    >
+      <div className="flex items-center justify-center">
+        <div className="relative">
+          <svg
+            width={size}
+            height={size}
+            viewBox={`0 0 ${size} ${size}`}
+            className="-rotate-90"
+            aria-hidden="true"
+          >
+            <circle
+              cx={size / 2}
+              cy={size / 2}
+              r={radius}
+              fill="none"
+              stroke="rgba(255,255,255,0.08)"
+              strokeWidth={strokeWidth}
+            />
+            <circle
+              cx={size / 2}
+              cy={size / 2}
+              r={radius}
+              fill="none"
+              stroke={dial.status === "unavailable" ? "rgba(125,133,144,0.35)" : accent}
+              strokeWidth={strokeWidth}
+              strokeLinecap="round"
+              strokeDasharray={
+                dial.status === "unavailable"
+                  ? `${circumference / 18} ${circumference / 22}`
+                  : circumference
+              }
+              strokeDashoffset={dashOffset}
+              style={{
+                transition: "stroke-dashoffset 320ms ease, stroke 220ms ease",
+                filter:
+                  dial.status === "unavailable"
+                    ? "none"
+                    : `drop-shadow(0 0 12px color-mix(in srgb, ${accent} 32%, transparent))`,
+              }}
+            />
+          </svg>
+          <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center text-center">
+            <div
+              className={cn(
+                "font-[var(--font-mono)] font-semibold tabular-nums text-[var(--color-text-primary)]",
+                valueClassName(dial.displayValue),
+              )}
+            >
+              {dial.status === "unlimited" ? "∞" : dial.displayValue}
+            </div>
+            {dial.status === "unlimited" && (
+              <div className="mt-0.5 text-[9px] uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
+                unlimited
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+      <div className="mt-2 space-y-1 text-center">
+        <div className="text-[11px] font-medium leading-snug text-[var(--color-text-secondary)]">
+          {dial.label}
+        </div>
+        <div className="text-[10px] text-[var(--color-text-tertiary)]">{helperText}</div>
+      </div>
+    </div>
+  );
+}
+
+function UsageProviderSection({
+  snapshot,
+  compact = false,
+}: {
+  snapshot: UsageSnapshot;
+  compact?: boolean;
+}) {
+  const meta = PROVIDER_META[snapshot.provider];
+
+  return (
+    <section
+      className="overflow-hidden rounded-[14px] border border-[var(--color-border-default)]"
+      style={{
+        background: `linear-gradient(180deg, ${meta.glow} 0%, rgba(255,255,255,0.02) 32%, rgba(255,255,255,0.02) 100%)`,
+        boxShadow: `0 14px 32px rgba(0,0,0,0.18), inset 0 1px 0 rgba(255,255,255,0.04)`,
+      }}
+    >
+      <div className="border-b border-[var(--color-border-subtle)] px-4 py-3">
+        <div className="flex items-center gap-2">
+          <span
+            className="h-2 w-2 rounded-full"
+            style={{ background: meta.accent, boxShadow: `0 0 14px ${meta.glow}` }}
+          />
+          <h3 className="text-[13px] font-semibold text-[var(--color-text-primary)]">
+            {meta.title}
+          </h3>
+        </div>
+        <div className="mt-1 flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-[0.11em] text-[var(--color-text-tertiary)]">
+          <span>{meta.heading}</span>
+          {snapshot.plan && (
+            <span className="rounded-full border border-[var(--color-border-subtle)] px-2 py-0.5 normal-case tracking-normal text-[10px]">
+              {snapshot.plan}
+            </span>
+          )}
+        </div>
+      </div>
+      <div
+        className={cn(
+          "grid gap-3 p-4",
+          compact ? "grid-cols-1 sm:grid-cols-2 xl:grid-cols-4" : "grid-cols-1 sm:grid-cols-2 xl:grid-cols-3",
+        )}
+      >
+        {snapshot.dials.map((dial) => (
+          <CircularUsageDial
+            key={`${snapshot.provider}-${dial.id}`}
+            dial={dial}
+            accent={meta.accent}
+            compact={compact}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function UsageMetric({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: string;
+  accent: string;
+}) {
+  return (
+    <div className="rounded-[12px] border border-[var(--color-border-subtle)] bg-[rgba(255,255,255,0.03)] px-3 py-3">
+      <div className="text-[10px] uppercase tracking-[0.11em] text-[var(--color-text-tertiary)]">
+        {label}
+      </div>
+      <div className="mt-1 font-[var(--font-mono)] text-[18px] font-semibold tabular-nums" style={{ color: accent }}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: value < 0.1 ? 3 : 2,
+    maximumFractionDigits: value < 0.1 ? 3 : 2,
+  }).format(value);
+}
+
+export function UsagePanels({ snapshots, compact = false }: UsagePanelsProps) {
+  return (
+    <div className="space-y-4">
+      {snapshots.map((snapshot) => (
+        <UsageProviderSection
+          key={snapshot.provider}
+          snapshot={snapshot}
+          compact={compact}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function SessionUsageCard({ cost, snapshot }: SessionUsageCardProps) {
+  if (!cost && !snapshot) {
+    return null;
+  }
+
+  const accent = snapshot ? PROVIDER_META[snapshot.provider].accent : "var(--color-accent)";
+
+  return (
+    <div className="detail-card mb-6 rounded-[8px] border border-[var(--color-border-default)] p-5">
+      <div className="mb-4 flex items-center gap-2">
+        <div className="h-3 w-0.5 rounded-full" style={{ background: accent, opacity: 0.8 }} />
+        <span className="text-[10px] font-bold uppercase tracking-[0.10em] text-[var(--color-text-tertiary)]">
+          Usage
+        </span>
+      </div>
+
+      {cost && (
+        <div className="mb-4 grid gap-3 sm:grid-cols-3">
+          <UsageMetric
+            label="Input tokens"
+            value={new Intl.NumberFormat("en-US").format(cost.inputTokens)}
+            accent={accent}
+          />
+          <UsageMetric
+            label="Output tokens"
+            value={new Intl.NumberFormat("en-US").format(cost.outputTokens)}
+            accent={accent}
+          />
+          <UsageMetric
+            label="Estimated cost"
+            value={formatCurrency(cost.estimatedCostUsd)}
+            accent={accent}
+          />
+        </div>
+      )}
+
+      {snapshot && <UsageProviderSection snapshot={snapshot} compact />}
+    </div>
+  );
+}

--- a/packages/web/src/components/UsageOverview.tsx
+++ b/packages/web/src/components/UsageOverview.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { startTransition, useEffect, useState } from "react";
+import { UsagePanels } from "./UsageDials";
+import type { DashboardUsageResponse } from "@/lib/types";
+
+interface UsageOverviewProps {
+  refreshIntervalMs?: number;
+}
+
+export function UsageOverview({ refreshIntervalMs = 60_000 }: UsageOverviewProps) {
+  const [usage, setUsage] = useState<DashboardUsageResponse | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchUsage = async () => {
+      try {
+        const response = await fetch("/api/usage");
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+
+        const data = (await response.json()) as DashboardUsageResponse;
+        if (!cancelled) {
+          startTransition(() => {
+            setUsage(data);
+            setError(false);
+          });
+        }
+      } catch (fetchError) {
+        console.error("Failed to fetch usage:", fetchError);
+        if (!cancelled) {
+          startTransition(() => {
+            setError(true);
+          });
+        }
+      }
+    };
+
+    void fetchUsage();
+    const intervalId = window.setInterval(() => {
+      void fetchUsage();
+    }, refreshIntervalMs);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [refreshIntervalMs]);
+
+  return (
+    <section className="mb-8">
+      <div className="mb-3 px-1">
+        <h2 className="text-[10px] font-bold uppercase tracking-[0.10em] text-[var(--color-text-tertiary)]">
+          Subscription Usage
+        </h2>
+        <p className="mt-1 text-[12px] text-[var(--color-text-secondary)]">
+          Live subscription dials from active Codex and Claude Code sessions.
+        </p>
+      </div>
+
+      {usage ? (
+        <UsagePanels snapshots={usage.snapshots} />
+      ) : (
+        <div className="rounded-[14px] border border-[var(--color-border-subtle)] bg-[rgba(255,255,255,0.03)] px-4 py-5 text-[13px] text-[var(--color-text-secondary)]">
+          {error ? "Usage data is temporarily unavailable." : "Loading usage dials…"}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -24,6 +24,7 @@ import {
 // Static plugin imports — webpack needs these to be string literals
 import pluginRuntimeTmux from "@composio/ao-plugin-runtime-tmux";
 import pluginAgentClaudeCode from "@composio/ao-plugin-agent-claude-code";
+import pluginAgentCodex from "@composio/ao-plugin-agent-codex";
 import pluginAgentOpencode from "@composio/ao-plugin-agent-opencode";
 import pluginWorkspaceWorktree from "@composio/ao-plugin-workspace-worktree";
 import pluginScmGithub from "@composio/ao-plugin-scm-github";
@@ -65,6 +66,7 @@ async function initServices(): Promise<Services> {
   // Register plugins explicitly (webpack can't handle dynamic import() in core)
   registry.register(pluginRuntimeTmux);
   registry.register(pluginAgentClaudeCode);
+  registry.register(pluginAgentCodex);
   registry.register(pluginAgentOpencode);
   registry.register(pluginWorkspaceWorktree);
   registry.register(pluginScmGithub);

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -15,6 +15,10 @@ export type {
   ReviewDecision,
   MergeReadiness,
   PRState,
+  CostEstimate,
+  UsageDial,
+  UsageProvider,
+  UsageSnapshot,
 } from "@composio/ao-core/types";
 
 import {
@@ -30,6 +34,9 @@ import {
   type SessionStatus,
   type ActivityState,
   type ReviewDecision,
+  type CostEstimate,
+  type UsageProvider,
+  type UsageSnapshot,
 } from "@composio/ao-core/types";
 
 // Re-export for use in client components
@@ -125,6 +132,18 @@ export interface DashboardStats {
   workingSessions: number;
   openPRs: number;
   needsReview: number;
+}
+
+export interface DashboardUsageResponse {
+  updatedAt: string;
+  snapshots: UsageSnapshot[];
+}
+
+export interface SessionUsageResponse {
+  sessionId: string;
+  provider: UsageProvider | null;
+  cost: CostEstimate | null;
+  snapshot: UsageSnapshot | null;
 }
 
 /** SSE snapshot event from /api/events */

--- a/packages/web/src/lib/usage.ts
+++ b/packages/web/src/lib/usage.ts
@@ -1,0 +1,223 @@
+import type {
+  Agent,
+  CostEstimate,
+  OrchestratorConfig,
+  PluginRegistry,
+  Session,
+  UsageDial,
+  UsageDialKind,
+  UsageProvider,
+  UsageSnapshot,
+} from "@composio/ao-core";
+import type { DashboardUsageResponse, SessionUsageResponse } from "@/lib/types";
+import { resolveProject } from "@/lib/serialize";
+
+interface UsageDialTemplate {
+  id: string;
+  kind: UsageDialKind;
+  label: string;
+}
+
+interface SessionUsageSource {
+  provider: UsageProvider | null;
+  snapshot: UsageSnapshot | null;
+  cost: CostEstimate | null;
+}
+
+const PROVIDER_ORDER: UsageProvider[] = ["codex", "claude-code"];
+
+const DIAL_TEMPLATES: Record<UsageProvider, UsageDialTemplate[]> = {
+  codex: [
+    { id: "codex-5h", label: "5 hour usage limit", kind: "percent_remaining" },
+    { id: "codex-weekly", label: "Weekly usage limit", kind: "percent_remaining" },
+    {
+      id: "codex-spark-5h",
+      label: "GPT-5.3-Codex-Spark 5 hour usage limit",
+      kind: "percent_remaining",
+    },
+    {
+      id: "codex-spark-weekly",
+      label: "GPT-5.3-Codex-Spark Weekly usage limit",
+      kind: "percent_remaining",
+    },
+    { id: "codex-code-review", label: "Code review", kind: "percent_remaining" },
+    { id: "codex-credits", label: "Credits remaining", kind: "absolute" },
+  ],
+  "claude-code": [
+    {
+      id: "claude-current-session",
+      label: "Current session usage",
+      kind: "percent_used",
+    },
+    {
+      id: "claude-weekly-all-models",
+      label: "Weekly limits - All models",
+      kind: "percent_used",
+    },
+  ],
+};
+
+function providerForAgentName(agentName: string | undefined): UsageProvider | null {
+  switch (agentName) {
+    case "codex":
+      return "codex";
+    case "claude-code":
+      return "claude-code";
+    default:
+      return null;
+  }
+}
+
+function makeUnavailableDial(template: UsageDialTemplate): UsageDial {
+  return {
+    id: template.id,
+    label: template.label,
+    kind: template.kind,
+    status: "unavailable",
+    value: null,
+    maxValue: template.kind === "absolute" ? null : 100,
+    displayValue: "--",
+    resetsAt: null,
+  };
+}
+
+function normalizeSnapshot(
+  provider: UsageProvider,
+  snapshot: UsageSnapshot | null,
+): UsageSnapshot {
+  const dialMap = new Map(snapshot?.dials.map((dial) => [dial.id, dial]));
+
+  return {
+    provider,
+    plan: snapshot?.plan ?? null,
+    capturedAt: snapshot?.capturedAt ?? new Date().toISOString(),
+    dials: DIAL_TEMPLATES[provider].map(
+      (template) => dialMap.get(template.id) ?? makeUnavailableDial(template),
+    ),
+  };
+}
+
+function parseSnapshotTime(snapshot: UsageSnapshot): number {
+  const parsed = Date.parse(snapshot.capturedAt);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function mergeSnapshots(
+  provider: UsageProvider,
+  snapshots: UsageSnapshot[],
+): UsageSnapshot | null {
+  if (snapshots.length === 0) return null;
+
+  let latestSnapshot = snapshots[0];
+  const dialEntries = new Map<string, { dial: UsageDial; timestamp: number }>();
+
+  for (const snapshot of snapshots) {
+    const timestamp = parseSnapshotTime(snapshot);
+    if (timestamp >= parseSnapshotTime(latestSnapshot)) {
+      latestSnapshot = snapshot;
+    }
+
+    for (const dial of snapshot.dials) {
+      const existing = dialEntries.get(dial.id);
+      if (!existing || timestamp >= existing.timestamp) {
+        dialEntries.set(dial.id, { dial, timestamp });
+      }
+    }
+  }
+
+  return {
+    provider,
+    plan: latestSnapshot.plan ?? null,
+    capturedAt: latestSnapshot.capturedAt,
+    dials: Array.from(dialEntries.values()).map(({ dial }) => dial),
+  };
+}
+
+function resolveAgent(
+  session: Session,
+  config: OrchestratorConfig,
+  registry: PluginRegistry,
+): { agent: Agent | null; provider: UsageProvider | null } {
+  const project = resolveProject(session, config.projects);
+  const agentName = session.metadata["agent"] ?? project?.agent ?? config.defaults.agent;
+  const provider = providerForAgentName(agentName);
+
+  try {
+    return {
+      agent: registry.get<Agent>("agent", agentName),
+      provider,
+    };
+  } catch {
+    return { agent: null, provider };
+  }
+}
+
+async function loadSessionUsageSource(
+  session: Session,
+  config: OrchestratorConfig,
+  registry: PluginRegistry,
+  opts?: { includeCost?: boolean },
+): Promise<SessionUsageSource> {
+  const { agent, provider } = resolveAgent(session, config, registry);
+  if (!agent || !provider) {
+    return { provider: null, snapshot: null, cost: null };
+  }
+
+  const snapshotPromise = agent.getUsageSnapshot
+    ? agent.getUsageSnapshot(session).catch(() => null)
+    : Promise.resolve<UsageSnapshot | null>(null);
+
+  const costPromise =
+    opts?.includeCost === true
+      ? session.agentInfo?.cost
+        ? Promise.resolve(session.agentInfo.cost)
+        : agent.getSessionInfo(session).then((info) => info?.cost ?? null).catch(() => null)
+      : Promise.resolve<CostEstimate | null>(null);
+
+  const [snapshot, cost] = await Promise.all([snapshotPromise, costPromise]);
+  return { provider, snapshot, cost };
+}
+
+export async function getDashboardUsage(
+  sessions: Session[],
+  config: OrchestratorConfig,
+  registry: PluginRegistry,
+): Promise<DashboardUsageResponse> {
+  const workerSessions = sessions.filter(
+    (session) => !session.id.endsWith("-orchestrator") && session.activity !== "exited",
+  );
+  const sessionUsage = await Promise.all(
+    workerSessions.map((session) => loadSessionUsageSource(session, config, registry)),
+  );
+
+  const mergedSnapshots = PROVIDER_ORDER.map((provider) => {
+    const providerSnapshots = sessionUsage
+      .filter((entry): entry is SessionUsageSource & { provider: UsageProvider } => {
+        return entry.provider === provider;
+      })
+      .map((entry) => entry.snapshot)
+      .filter((snapshot): snapshot is UsageSnapshot => snapshot !== null);
+
+    return normalizeSnapshot(provider, mergeSnapshots(provider, providerSnapshots));
+  });
+
+  return {
+    updatedAt: new Date().toISOString(),
+    snapshots: mergedSnapshots,
+  };
+}
+
+export async function getSessionUsage(
+  session: Session,
+  config: OrchestratorConfig,
+  registry: PluginRegistry,
+): Promise<SessionUsageResponse> {
+  const source = await loadSessionUsageSource(session, config, registry, { includeCost: true });
+
+  return {
+    sessionId: session.id,
+    provider: source.provider,
+    cost: source.cost,
+    snapshot: source.provider ? normalizeSnapshot(source.provider, source.snapshot) : null,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,6 +528,9 @@ importers:
       '@composio/ao-plugin-agent-claude-code':
         specifier: workspace:*
         version: link:../plugins/agent-claude-code
+      '@composio/ao-plugin-agent-codex':
+        specifier: workspace:*
+        version: link:../plugins/agent-codex
       '@composio/ao-plugin-agent-opencode':
         specifier: workspace:*
         version: link:../plugins/agent-opencode
@@ -3605,6 +3608,7 @@ packages:
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}


### PR DESCRIPTION
## Summary
- Codex and Claude Code now expose normalized getUsageSnapshot() data from session files
- Web app serves usage through GET /api/usage and GET /api/sessions/:id/usage  
- Dashboard/session detail UI renders circular dials grouped by provider with reset times plus per-session token/cost summaries

## Validation
- pnpm run typecheck
- pnpm test  
- pnpm run lint

Closes #18