### PR TITLE
fix: clean up auto-merged sessions after merge

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { createLifecycleManager } from "../lifecycle-manager.js";
 import { createSessionManager } from "../session-manager.js";
-import { writeMetadata, readMetadataRaw } from "../metadata.js";
-import { getSessionsDir, getProjectBaseDir } from "../paths.js";
+import { deleteMetadata, writeMetadata, readMetadataRaw } from "../metadata.js";
+import { getSessionsDir, getProjectBaseDir, getWorktreesDir } from "../paths.js";
 import type {
   OrchestratorConfig,
   PluginRegistry,
@@ -62,6 +63,35 @@ function makePR(overrides: Partial<PRInfo> = {}): PRInfo {
     isDraft: false,
     ...overrides,
   };
+}
+
+function runGit(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf-8" }).trim();
+}
+
+function createManagedWorktree(sessionId = "app-1", branch = "feat/test"): {
+  repoPath: string;
+  worktreePath: string;
+} {
+  const repoPath = config.projects["my-app"]?.path;
+  if (!repoPath) {
+    throw new Error("missing repo path");
+  }
+
+  mkdirSync(repoPath, { recursive: true });
+  runGit(repoPath, "init", "-b", "main");
+  runGit(repoPath, "config", "user.email", "ao@example.com");
+  runGit(repoPath, "config", "user.name", "AO Test");
+  writeFileSync(join(repoPath, "README.md"), "hello\n", "utf-8");
+  runGit(repoPath, "add", "README.md");
+  runGit(repoPath, "commit", "-m", "init");
+
+  const worktreeDir = getWorktreesDir(configPath, repoPath);
+  mkdirSync(worktreeDir, { recursive: true });
+  const worktreePath = join(worktreeDir, sessionId);
+  runGit(repoPath, "worktree", "add", "-b", branch, worktreePath, "HEAD");
+
+  return { repoPath, worktreePath };
 }
 
 function getLifecycleLogs(): Array<Record<string, unknown>> {
@@ -1222,6 +1252,289 @@ describe("reactions", () => {
 
     const metadata = readMetadataRaw(sessionsDir, "app-1");
     expect(metadata?.["lastAutomatedReviewDispatchHash"]).toBe("bot-1");
+  });
+
+  it("auto-merges, cleans the session, and emits session.completed after cleanup", async () => {
+    config.reactions = {
+      "approved-and-green": {
+        auto: true,
+        action: "auto-merge",
+      },
+    };
+    config.projects["my-app"] = {
+      ...config.projects["my-app"]!,
+      workspace: "worktree",
+    };
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mergeability = {
+      mergeable: true,
+      ciPassing: true,
+      approved: true,
+      noConflicts: true,
+      blockers: [],
+    };
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn().mockResolvedValue(undefined),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("approved"),
+      getPendingComments: vi.fn().mockResolvedValue([]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn().mockResolvedValue(mergeability),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const { repoPath, worktreePath } = createManagedWorktree("app-1", "feat/test");
+    const session = makeSession({
+      status: "pr_open",
+      branch: "feat/test",
+      workspacePath: worktreePath,
+      pr: makePR({ branch: "feat/test" }),
+    });
+
+    let getCount = 0;
+    vi.mocked(mockSessionManager.get).mockImplementation(async () => {
+      getCount += 1;
+      return getCount >= 3 ? null : session;
+    });
+    vi.mocked(mockSessionManager.kill).mockImplementation(async () => {
+      runGit(repoPath, "worktree", "remove", "--force", worktreePath);
+      runGit(repoPath, "branch", "-D", "feat/test");
+      deleteMetadata(sessionsDir, "app-1", true);
+    });
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: worktreePath,
+      branch: "feat/test",
+      status: "pr_open",
+      project: "my-app",
+      pr: session.pr?.url,
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(mockSCM.mergePR).toHaveBeenCalledWith(session.pr);
+    expect(existsSync(worktreePath)).toBe(false);
+    expect(runGit(repoPath, "branch", "--list", "feat/test")).toBe("");
+    expect(readMetadataRaw(sessionsDir, "app-1")).toBeNull();
+    expect(lm.getStates().get("app-1")).toBeUndefined();
+
+    const notifiedTypes = vi
+      .mocked(mockNotifier.notify)
+      .mock.calls.map(([event]) => event.type);
+    expect(notifiedTypes).toEqual(["merge.completed", "session.completed"]);
+  });
+
+  it("emits session.completed after fallback cleanup when session kill reports a recoverable error", async () => {
+    config.reactions = {
+      "approved-and-green": {
+        auto: true,
+        action: "auto-merge",
+      },
+    };
+    config.projects["my-app"] = {
+      ...config.projects["my-app"]!,
+      workspace: "worktree",
+    };
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mergeability = {
+      mergeable: true,
+      ciPassing: true,
+      approved: true,
+      noConflicts: true,
+      blockers: [],
+    };
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn().mockResolvedValue(undefined),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("approved"),
+      getPendingComments: vi.fn().mockResolvedValue([]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn().mockResolvedValue(mergeability),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const { repoPath, worktreePath } = createManagedWorktree("app-1", "feat/test");
+    const session = makeSession({
+      status: "pr_open",
+      branch: "feat/test",
+      workspacePath: worktreePath,
+      pr: makePR({ branch: "feat/test" }),
+    });
+
+    let getCount = 0;
+    vi.mocked(mockSessionManager.get).mockImplementation(async () => {
+      getCount += 1;
+      return getCount >= 3 ? null : session;
+    });
+    vi.mocked(mockSessionManager.kill).mockImplementation(async () => {
+      deleteMetadata(sessionsDir, "app-1", true);
+      throw new Error("runtime cleanup failed");
+    });
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: worktreePath,
+      branch: "feat/test",
+      status: "pr_open",
+      project: "my-app",
+      pr: session.pr?.url,
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(mockSCM.mergePR).toHaveBeenCalledWith(session.pr);
+    expect(existsSync(worktreePath)).toBe(false);
+    expect(runGit(repoPath, "branch", "--list", "feat/test")).toBe("");
+    expect(readMetadataRaw(sessionsDir, "app-1")).toBeNull();
+    expect(lm.getStates().get("app-1")).toBeUndefined();
+
+    const notifiedTypes = vi
+      .mocked(mockNotifier.notify)
+      .mock.calls.map(([event]) => event.type);
+    expect(notifiedTypes).toEqual(["merge.completed", "session.completed"]);
+  });
+
+  it("escalates when auto-merge succeeds but the session is still not fully cleaned", async () => {
+    config.reactions = {
+      "approved-and-green": {
+        auto: true,
+        action: "auto-merge",
+      },
+    };
+    config.projects["my-app"] = {
+      ...config.projects["my-app"]!,
+      workspace: "worktree",
+    };
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mergeability = {
+      mergeable: true,
+      ciPassing: true,
+      approved: true,
+      noConflicts: true,
+      blockers: [],
+    };
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn().mockResolvedValue(undefined),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("approved"),
+      getPendingComments: vi.fn().mockResolvedValue([]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn().mockResolvedValue(mergeability),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const { repoPath, worktreePath } = createManagedWorktree("app-1", "feat/test");
+    const session = makeSession({
+      status: "pr_open",
+      branch: "feat/test",
+      workspacePath: worktreePath,
+      pr: makePR({ branch: "feat/test" }),
+    });
+
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    vi.mocked(mockSessionManager.kill).mockImplementation(async () => {
+      throw new Error("runtime cleanup failed");
+    });
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: worktreePath,
+      branch: "feat/test",
+      status: "pr_open",
+      project: "my-app",
+      pr: session.pr?.url,
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(existsSync(worktreePath)).toBe(false);
+    expect(runGit(repoPath, "branch", "--list", "feat/test")).toBe("");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("merged");
+    expect(lm.getStates().get("app-1")).toBe("merged");
+
+    const notifiedTypes = vi
+      .mocked(mockNotifier.notify)
+      .mock.calls.map(([event]) => event.type);
+    expect(notifiedTypes).toEqual(["merge.completed", "reaction.escalated"]);
   });
 
   it("notifies humans on significant transitions without reaction config", async () => {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -35,6 +35,11 @@ import {
 } from "./types.js";
 import { updateMetadata } from "./metadata.js";
 import { getSessionsDir } from "./paths.js";
+import {
+  deleteLocalBranch,
+  forceRemoveGitWorktree,
+  verifyGitSessionCleanup,
+} from "./session-cleanup.js";
 
 /** Parse a duration string like "10m", "30s", "1h" to milliseconds. */
 function parseDuration(str: string): number {
@@ -245,6 +250,10 @@ function incrementPollError(pollStats?: LifecyclePollStats): void {
   if (pollStats) {
     pollStats.errors += 1;
   }
+}
+
+function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 function createPollStats(): LifecyclePollStats {
@@ -600,21 +609,189 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       }
 
       case "auto-merge": {
-        // Auto-merge is handled by the SCM plugin
-        // For now, just notify
-        const event = createEvent("reaction.triggered", {
-          sessionId,
-          projectId,
-          message: `Reaction '${reactionKey}' triggered auto-merge`,
-          data: { reactionKey },
-        });
-        await notifyHuman(event, "action", pollStats);
-        return {
-          reactionType: reactionKey,
-          success: true,
-          action: "auto-merge",
-          escalated: false,
-        };
+        const session = await sessionManager.get(sessionId);
+        const project = config.projects[projectId];
+        const scm = project?.scm ? registry.get<SCM>("scm", project.scm.plugin) : null;
+
+        if (!session || !project || !session.pr || !scm) {
+          const message = !session
+            ? `Auto-merge could not load session ${sessionId}`
+            : !project
+              ? `Auto-merge could not load project ${projectId}`
+              : !session.pr
+                ? `Auto-merge could not find a PR for session ${sessionId}`
+                : `Auto-merge could not load SCM plugin for project ${projectId}`;
+          await notifyReactionFailure(
+            sessionId,
+            projectId,
+            reactionKey,
+            reactionConfig.priority ?? "urgent",
+            message,
+            { reason: "missing_merge_context" },
+            pollStats,
+          );
+          return {
+            reactionType: reactionKey,
+            success: false,
+            action: "auto-merge",
+            escalated: true,
+          };
+        }
+
+        try {
+          const prState = await scm.getPRState(session.pr);
+          const alreadyMerged = prState === PR_STATE.MERGED;
+
+          if (!alreadyMerged) {
+            if (prState !== PR_STATE.OPEN) {
+              const message = `Auto-merge aborted because PR #${session.pr.number} is ${prState}`;
+              await notifyReactionFailure(
+                sessionId,
+                projectId,
+                reactionKey,
+                reactionConfig.priority ?? "urgent",
+                message,
+                { pr: session.pr, prState },
+                pollStats,
+              );
+              return {
+                reactionType: reactionKey,
+                success: false,
+                action: "auto-merge",
+                escalated: true,
+              };
+            }
+
+            const mergeability = await scm.getMergeability(session.pr);
+            if (!mergeability.mergeable) {
+              const message = `Auto-merge aborted because PR #${session.pr.number} is no longer mergeable`;
+              await notifyReactionFailure(
+                sessionId,
+                projectId,
+                reactionKey,
+                reactionConfig.priority ?? "urgent",
+                message,
+                { pr: session.pr, blockers: mergeability.blockers },
+                pollStats,
+              );
+              return {
+                reactionType: reactionKey,
+                success: false,
+                action: "auto-merge",
+                escalated: true,
+              };
+            }
+
+            await scm.mergePR(session.pr);
+            logLifecycle("info", "reaction.auto_merge.merged", {
+              pollId: pollStats?.pollId,
+              projectId,
+              sessionId,
+              reactionKey,
+              prNumber: session.pr.number,
+              prUrl: session.pr.url,
+            });
+          } else {
+            logLifecycle("info", "reaction.auto_merge.already_merged", {
+              pollId: pollStats?.pollId,
+              projectId,
+              sessionId,
+              reactionKey,
+              prNumber: session.pr.number,
+              prUrl: session.pr.url,
+            });
+          }
+
+          await emitLifecycleEvent(
+            "merge.completed",
+            {
+              sessionId,
+              projectId,
+              message: `PR #${session.pr.number} merged for ${sessionId}`,
+              data: {
+                reactionKey,
+                pr: session.pr,
+                autoMerge: true,
+                alreadyMerged,
+              },
+            },
+            pollStats,
+          );
+
+          const cleanupResult = await cleanupMergedSession(session, pollStats);
+          if (!cleanupResult.completed) {
+            const message = `Auto-merge cleaned PR #${session.pr.number} but session ${sessionId} is not fully cleaned`;
+            await notifyReactionFailure(
+              sessionId,
+              projectId,
+              reactionKey,
+              reactionConfig.priority ?? "urgent",
+              message,
+              {
+                pr: session.pr,
+                autoMerge: true,
+                cleanupFailures: cleanupResult.failures,
+              },
+              pollStats,
+            );
+            return {
+              reactionType: reactionKey,
+              success: false,
+              action: "auto-merge",
+              escalated: true,
+              statusOverride: "merged",
+            };
+          }
+
+          await emitLifecycleEvent(
+            "session.completed",
+            {
+              sessionId,
+              projectId,
+              message: `Session ${sessionId} cleanup completed after auto-merge`,
+              data: {
+                reactionKey,
+                pr: session.pr,
+                autoMerge: true,
+                cleanupRecovered: cleanupResult.recovered,
+              },
+            },
+            pollStats,
+          );
+
+          return {
+            reactionType: reactionKey,
+            success: true,
+            action: "auto-merge",
+            escalated: false,
+            sessionCompleted: true,
+            statusOverride: "merged",
+          };
+        } catch (error) {
+          incrementPollError(pollStats);
+          logLifecycle("error", "reaction.auto_merge.failed", {
+            pollId: pollStats?.pollId,
+            projectId,
+            sessionId,
+            reactionKey,
+            error,
+          });
+          await notifyReactionFailure(
+            sessionId,
+            projectId,
+            reactionKey,
+            reactionConfig.priority ?? "urgent",
+            `Auto-merge failed for session ${sessionId}: ${formatError(error)}`,
+            { error: formatError(error) },
+            pollStats,
+          );
+          return {
+            reactionType: reactionKey,
+            success: false,
+            action: "auto-merge",
+            escalated: true,
+          };
+        }
       }
     }
 
@@ -628,6 +805,14 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
   function clearReactionTracker(sessionId: SessionId, reactionKey: string): void {
     reactionTrackers.delete(`${sessionId}:${reactionKey}`);
+  }
+
+  function clearAllReactionTrackers(sessionId: SessionId): void {
+    for (const trackerKey of [...reactionTrackers.keys()]) {
+      if (trackerKey.startsWith(`${sessionId}:`)) {
+        reactionTrackers.delete(trackerKey);
+      }
+    }
   }
 
   function getReactionConfigForSession(
@@ -661,6 +846,189 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       cleaned[key] = value;
     }
     session.metadata = cleaned;
+  }
+
+  async function emitLifecycleEvent(
+    type: EventType,
+    opts: {
+      sessionId: SessionId;
+      projectId: string;
+      message: string;
+      data?: Record<string, unknown>;
+      priority?: EventPriority;
+    },
+    pollStats?: LifecyclePollStats,
+  ): Promise<void> {
+    const event = createEvent(type, opts);
+    await notifyHuman(event, opts.priority ?? inferPriority(type), pollStats);
+  }
+
+  async function notifyReactionFailure(
+    sessionId: SessionId,
+    projectId: string,
+    reactionKey: string,
+    priority: EventPriority,
+    message: string,
+    data: Record<string, unknown>,
+    pollStats?: LifecyclePollStats,
+  ): Promise<void> {
+    logLifecycle("error", "reaction.auto_merge.escalated", {
+      pollId: pollStats?.pollId,
+      projectId,
+      sessionId,
+      reactionKey,
+      message,
+      ...data,
+    });
+    await emitLifecycleEvent(
+      "reaction.escalated",
+      {
+        sessionId,
+        projectId,
+        message,
+        priority,
+        data: { reactionKey, ...data },
+      },
+      pollStats,
+    );
+  }
+
+  async function cleanupMergedSession(
+    session: Session,
+    pollStats?: LifecyclePollStats,
+  ): Promise<{ completed: boolean; recovered: boolean; failures: string[] }> {
+    const project = config.projects[session.projectId];
+    if (!project) {
+      return {
+        completed: false,
+        recovered: false,
+        failures: [`project ${session.projectId} is not configured`],
+      };
+    }
+
+    const usesGitWorktreeCleanup = (project.workspace ?? config.defaults.workspace) === "worktree";
+    let recovered = false;
+    let killError: string | null = null;
+    const fallbackFailures: string[] = [];
+
+    try {
+      await sessionManager.kill(session.id);
+    } catch (error) {
+      killError = formatError(error);
+      incrementPollError(pollStats);
+      logLifecycle("error", "reaction.auto_merge.session_kill.failed", {
+        pollId: pollStats?.pollId,
+        projectId: session.projectId,
+        sessionId: session.id,
+        error,
+      });
+    }
+
+    if (
+      usesGitWorktreeCleanup &&
+      session.workspacePath &&
+      session.workspacePath !== project.path
+    ) {
+      const preVerify = await verifyGitSessionCleanup({
+        repoPath: project.path,
+        workspacePath: session.workspacePath,
+        branch: session.branch,
+        defaultBranch: project.defaultBranch,
+      });
+
+      const needsWorktreeFallback = preVerify.failures.some((failure) =>
+        failure.includes("worktree") || failure.includes("workspace"),
+      );
+      if (needsWorktreeFallback) {
+        try {
+          await forceRemoveGitWorktree(project.path, session.workspacePath);
+          recovered = true;
+          logLifecycle("info", "reaction.auto_merge.worktree_force_removed", {
+            pollId: pollStats?.pollId,
+            projectId: session.projectId,
+            sessionId: session.id,
+            workspacePath: session.workspacePath,
+          });
+        } catch (error) {
+          incrementPollError(pollStats);
+          fallbackFailures.push(`worktree cleanup failed: ${formatError(error)}`);
+          logLifecycle("error", "reaction.auto_merge.worktree_force_remove.failed", {
+            pollId: pollStats?.pollId,
+            projectId: session.projectId,
+            sessionId: session.id,
+            workspacePath: session.workspacePath,
+            error,
+          });
+        }
+      }
+
+      const needsBranchFallback = preVerify.failures.some((failure) =>
+        failure.includes("branch"),
+      );
+      if (needsBranchFallback && session.branch && session.branch !== project.defaultBranch) {
+        try {
+          await deleteLocalBranch(project.path, session.branch);
+          recovered = true;
+          logLifecycle("info", "reaction.auto_merge.branch_force_deleted", {
+            pollId: pollStats?.pollId,
+            projectId: session.projectId,
+            sessionId: session.id,
+            branch: session.branch,
+          });
+        } catch (error) {
+          incrementPollError(pollStats);
+          fallbackFailures.push(`branch cleanup failed: ${formatError(error)}`);
+          logLifecycle("error", "reaction.auto_merge.branch_force_delete.failed", {
+            pollId: pollStats?.pollId,
+            projectId: session.projectId,
+            sessionId: session.id,
+            branch: session.branch,
+            error,
+          });
+        }
+      }
+    }
+
+    const finalFailures = [...fallbackFailures];
+    const postVerify = await verifyGitSessionCleanup({
+      repoPath: project.path,
+      workspacePath: usesGitWorktreeCleanup ? session.workspacePath : null,
+      branch: usesGitWorktreeCleanup ? session.branch : null,
+      defaultBranch: project.defaultBranch,
+    });
+    finalFailures.push(...postVerify.failures);
+
+    try {
+      const remainingSession = await sessionManager.get(session.id);
+      if (remainingSession) {
+        finalFailures.push(`session metadata still exists for ${session.id}`);
+      }
+    } catch (error) {
+      finalFailures.push(`failed to verify session metadata cleanup: ${formatError(error)}`);
+    }
+
+    if (finalFailures.length > 0) {
+      if (killError) {
+        finalFailures.unshift(`session kill reported: ${killError}`);
+      }
+      return {
+        completed: false,
+        recovered,
+        failures: [...new Set(finalFailures)],
+      };
+    }
+
+    if (killError) {
+      recovered = true;
+      logLifecycle("info", "reaction.auto_merge.cleanup_recovered", {
+        pollId: pollStats?.pollId,
+        projectId: session.projectId,
+        sessionId: session.id,
+        killError,
+      });
+    }
+
+    return { completed: true, recovered, failures: [] };
   }
 
   function makeFingerprint(ids: string[]): string {
@@ -922,6 +1290,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       tracked ?? ((session.metadata?.["status"] as SessionStatus | undefined) || session.status);
     const newStatus = await determineStatus(session, pollStats);
     let transitionReaction: { key: string; result: ReactionResult | null } | undefined;
+    let effectiveNewStatus = newStatus;
 
     if (newStatus !== oldStatus) {
       if (pollStats) {
@@ -976,6 +1345,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
                 pollStats,
               );
               transitionReaction = { key: reactionKey, result: reactionResult };
+              if (reactionResult.statusOverride) {
+                effectiveNewStatus = reactionResult.statusOverride;
+                states.set(session.id, effectiveNewStatus);
+                if (!reactionResult.sessionCompleted) {
+                  updateSessionMetadata(session, { status: effectiveNewStatus });
+                }
+              }
               // Reaction is handling this event — suppress immediate human notification.
               // "send-to-agent" retries + escalates on its own; "notify"/"auto-merge"
               // already call notifyHuman internally. Notifying here would bypass the
@@ -1004,7 +1380,19 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       states.set(session.id, newStatus);
     }
 
-    await maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction, pollStats);
+    if (transitionReaction?.result?.sessionCompleted) {
+      states.delete(session.id);
+      clearAllReactionTrackers(session.id);
+      return;
+    }
+
+    await maybeDispatchReviewBacklog(
+      session,
+      oldStatus,
+      effectiveNewStatus,
+      transitionReaction,
+      pollStats,
+    );
   }
 
   /** Run one polling cycle across all sessions. */

--- a/packages/core/src/session-cleanup.ts
+++ b/packages/core/src/session-cleanup.ts
@@ -1,0 +1,145 @@
+import { execFile } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export const GIT_CLEANUP_TIMEOUT_MS = 30_000;
+
+function getExitCode(err: unknown): number | null {
+  if (!(err instanceof Error) || !("code" in err)) return null;
+  const code = err.code;
+  return typeof code === "number" ? code : null;
+}
+
+function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export async function gitBranchExists(repoPath: string, branch: string): Promise<boolean> {
+  try {
+    await execFileAsync("git", ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`], {
+      cwd: repoPath,
+      timeout: GIT_CLEANUP_TIMEOUT_MS,
+    });
+    return true;
+  } catch (err: unknown) {
+    if (getExitCode(err) === 1) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+export async function isGitWorktreeRegistered(
+  repoPath: string,
+  workspacePath: string,
+): Promise<boolean> {
+  const { stdout } = await execFileAsync("git", ["worktree", "list", "--porcelain"], {
+    cwd: repoPath,
+    timeout: GIT_CLEANUP_TIMEOUT_MS,
+  });
+
+  const normalizedWorkspace = resolve(workspacePath);
+  return stdout.split("\n").some((line) => {
+    if (!line.startsWith("worktree ")) return false;
+    return resolve(line.slice("worktree ".length)) === normalizedWorkspace;
+  });
+}
+
+export async function forceRemoveGitWorktree(repoPath: string, workspacePath: string): Promise<void> {
+  try {
+    await execFileAsync("git", ["worktree", "remove", "--force", workspacePath], {
+      cwd: repoPath,
+      timeout: GIT_CLEANUP_TIMEOUT_MS,
+    });
+  } catch {
+    // Fall through — verify end state after prune + directory cleanup.
+  }
+
+  try {
+    await execFileAsync("git", ["worktree", "prune"], {
+      cwd: repoPath,
+      timeout: GIT_CLEANUP_TIMEOUT_MS,
+    });
+  } catch {
+    // Best effort — verification below decides success/failure.
+  }
+
+  if (existsSync(workspacePath)) {
+    rmSync(workspacePath, { recursive: true, force: true });
+  }
+
+  const stillExists = existsSync(workspacePath);
+  const stillRegistered = await isGitWorktreeRegistered(repoPath, workspacePath);
+  if (stillExists || stillRegistered) {
+    throw new Error(
+      [
+        stillRegistered ? `git still lists worktree ${workspacePath}` : null,
+        stillExists ? `directory still exists at ${workspacePath}` : null,
+      ]
+        .filter(Boolean)
+        .join("; "),
+    );
+  }
+}
+
+export async function deleteLocalBranch(
+  repoPath: string,
+  branch: string,
+): Promise<"deleted" | "missing"> {
+  if (!(await gitBranchExists(repoPath, branch))) {
+    return "missing";
+  }
+
+  await execFileAsync("git", ["branch", "-D", branch], {
+    cwd: repoPath,
+    timeout: GIT_CLEANUP_TIMEOUT_MS,
+  });
+
+  if (await gitBranchExists(repoPath, branch)) {
+    throw new Error(`branch ${branch} still exists after deletion attempt`);
+  }
+
+  return "deleted";
+}
+
+export interface GitCleanupVerification {
+  ok: boolean;
+  failures: string[];
+}
+
+export async function verifyGitSessionCleanup(options: {
+  repoPath: string;
+  workspacePath?: string | null;
+  branch?: string | null;
+  defaultBranch: string;
+}): Promise<GitCleanupVerification> {
+  const failures: string[] = [];
+
+  if (options.workspacePath) {
+    try {
+      if (existsSync(options.workspacePath)) {
+        failures.push(`workspace still exists at ${options.workspacePath}`);
+      }
+      if (await isGitWorktreeRegistered(options.repoPath, options.workspacePath)) {
+        failures.push(`git still lists worktree ${options.workspacePath}`);
+      }
+    } catch (err: unknown) {
+      failures.push(`failed to verify worktree cleanup: ${formatError(err)}`);
+    }
+  }
+
+  if (options.branch && options.branch !== options.defaultBranch) {
+    try {
+      if (await gitBranchExists(options.repoPath, options.branch)) {
+        failures.push(`local branch ${options.branch} still exists`);
+      }
+    } catch (err: unknown) {
+      failures.push(`failed to verify branch cleanup: ${formatError(err)}`);
+    }
+  }
+
+  return { ok: failures.length === 0, failures };
+}

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -11,7 +11,7 @@
  * Reference: scripts/claude-ao-session, scripts/send-to-session
  */
 
-import { statSync, existsSync, readdirSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { statSync, existsSync, readdirSync, writeFileSync, mkdirSync } from "node:fs";
 import { execFile } from "node:child_process";
 import { basename, join, resolve } from "node:path";
 import { homedir } from "node:os";
@@ -67,6 +67,7 @@ import {
 } from "./paths.js";
 import { asValidOpenCodeSessionId } from "./opencode-session-id.js";
 import { normalizeOrchestratorSessionStrategy } from "./orchestrator-session-strategy.js";
+import { deleteLocalBranch, forceRemoveGitWorktree } from "./session-cleanup.js";
 
 const execFileAsync = promisify(execFile);
 const OPENCODE_DISCOVERY_TIMEOUT_MS = 2_000;
@@ -75,7 +76,6 @@ const PROCESS_LIST_TIMEOUT_MS = 5_000;
 const PROCESS_TERMINATION_TIMEOUT_MS = 5_000;
 const PROCESS_TERMINATION_POLL_MS = 200;
 const TMUX_KILL_TIMEOUT_MS = 5_000;
-const GIT_CLEANUP_TIMEOUT_MS = 30_000;
 
 interface ProcessSnapshot {
   pid: number;
@@ -87,12 +87,6 @@ function getErrorCode(err: unknown): string | undefined {
   if (!(err instanceof Error) || !("code" in err)) return undefined;
   const code = err.code;
   return typeof code === "string" ? code : undefined;
-}
-
-function getExitCode(err: unknown): number | null {
-  if (!(err instanceof Error) || !("code" in err)) return null;
-  const code = err.code;
-  return typeof code === "number" ? code : null;
 }
 
 function formatError(err: unknown): string {
@@ -283,88 +277,6 @@ async function hasTmuxSession(sessionId: string): Promise<boolean> {
   } catch {
     return false;
   }
-}
-
-async function gitBranchExists(repoPath: string, branch: string): Promise<boolean> {
-  try {
-    await execFileAsync("git", ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`], {
-      cwd: repoPath,
-      timeout: GIT_CLEANUP_TIMEOUT_MS,
-    });
-    return true;
-  } catch (err: unknown) {
-    if (getExitCode(err) === 1) {
-      return false;
-    }
-    throw err;
-  }
-}
-
-async function isGitWorktreeRegistered(repoPath: string, workspacePath: string): Promise<boolean> {
-  const { stdout } = await execFileAsync("git", ["worktree", "list", "--porcelain"], {
-    cwd: repoPath,
-    timeout: GIT_CLEANUP_TIMEOUT_MS,
-  });
-
-  const normalizedWorkspace = resolve(workspacePath);
-  return stdout.split("\n").some((line) => {
-    if (!line.startsWith("worktree ")) return false;
-    return resolve(line.slice("worktree ".length)) === normalizedWorkspace;
-  });
-}
-
-async function forceRemoveGitWorktree(repoPath: string, workspacePath: string): Promise<void> {
-  try {
-    await execFileAsync("git", ["worktree", "remove", "--force", workspacePath], {
-      cwd: repoPath,
-      timeout: GIT_CLEANUP_TIMEOUT_MS,
-    });
-  } catch {
-    // Fall through — we verify end state after prune + directory cleanup.
-  }
-
-  try {
-    await execFileAsync("git", ["worktree", "prune"], {
-      cwd: repoPath,
-      timeout: GIT_CLEANUP_TIMEOUT_MS,
-    });
-  } catch {
-    // Best effort — verification below decides success/failure.
-  }
-
-  if (existsSync(workspacePath)) {
-    rmSync(workspacePath, { recursive: true, force: true });
-  }
-
-  const stillExists = existsSync(workspacePath);
-  const stillRegistered = await isGitWorktreeRegistered(repoPath, workspacePath);
-  if (stillExists || stillRegistered) {
-    throw new Error(
-      [
-        stillRegistered ? `git still lists worktree ${workspacePath}` : null,
-        stillExists ? `directory still exists at ${workspacePath}` : null,
-      ]
-        .filter(Boolean)
-        .join("; "),
-    );
-  }
-}
-
-async function deleteLocalBranch(repoPath: string, branch: string): Promise<"deleted" | "missing"> {
-  if (!(await gitBranchExists(repoPath, branch))) {
-    return "missing";
-  }
-
-  await execFileAsync("git", ["branch", "-D", branch], {
-    cwd: repoPath,
-    timeout: GIT_CLEANUP_TIMEOUT_MS,
-  });
-
-  if (await gitBranchExists(repoPath, branch)) {
-    throw new Error(`branch ${branch} still exists after deletion attempt`);
-  }
-
-  return "deleted";
 }
 
 function errorIncludesSessionNotFound(err: unknown): boolean {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -729,6 +729,7 @@ export type EventType =
   | "session.working"
   | "session.exited"
   | "session.killed"
+  | "session.completed"
   | "session.stuck"
   | "session.needs_input"
   | "session.errored"
@@ -810,6 +811,8 @@ export interface ReactionResult {
   action: string;
   message?: string;
   escalated: boolean;
+  sessionCompleted?: boolean;
+  statusOverride?: SessionStatus;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- implement the approved-and-green auto-merge path through the SCM plugin
- clean up the merged session, verify the worktree and branch are gone, and force-remove them as fallback when needed
- emit a dedicated session.completed event after cleanup and add lifecycle tests for success, recovery, and escalation cases

Closes #2