### PR TITLE
feat(core): deduplicate webhook deliveries with idempotency keys

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { createLifecycleManager } from "../lifecycle-manager.js";
 import { createSessionManager } from "../session-manager.js";
 import { deleteMetadata, writeMetadata, readMetadataRaw } from "../metadata.js";
@@ -81,6 +81,26 @@ function getLifecycleLogs(): Array<Record<string, unknown>> {
 
 function runGit(cwd: string, ...args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf-8" }).trim();
+}
+
+function computeEventIdempotencyKey(
+  sessionId: string,
+  transition: string,
+  oldStatus: string,
+  newStatus: string,
+  timestamp: Date,
+): string {
+  return createHash("sha256")
+    .update(
+      [
+        sessionId,
+        transition,
+        oldStatus,
+        newStatus,
+        String(Math.floor(timestamp.getTime() / 60_000)),
+      ].join(":"),
+    )
+    .digest("hex");
 }
 
 beforeEach(() => {
@@ -803,9 +823,123 @@ describe("check (single session)", () => {
     vi.setSystemTime(new Date("2026-03-09T11:01:01.000Z"));
     await lm.check("app-1");
 
+    const transitionTime = new Date("2026-03-09T11:01:01.000Z");
     expect(lm.getStates().get("app-1")).toBe("mergeable");
     expect(mockNotifier.notify).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "merge.ready" }),
+      expect.objectContaining({
+        type: "merge.ready",
+        idempotencyKey: computeEventIdempotencyKey(
+          "app-1",
+          "merge.ready",
+          "stuck",
+          "mergeable",
+          transitionTime,
+        ),
+      }),
+    );
+  });
+
+  it("deduplicates repeated transition notifications within the TTL window", async () => {
+    vi.useFakeTimers();
+    const transitionTime = new Date("2026-03-09T13:00:00.000Z");
+    vi.setSystemTime(transitionTime);
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("merged"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn(),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    vi.mocked(mockSessionManager.list)
+      .mockResolvedValueOnce([
+        makeSession({
+          status: "approved",
+          pr: makePR(),
+          metadata: { status: "approved" },
+        }),
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        makeSession({
+          status: "approved",
+          pr: makePR(),
+          metadata: { status: "approved" },
+        }),
+      ])
+      .mockResolvedValue([]);
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    lm.start(1_000);
+
+    await vi.waitFor(() => {
+      expect(mockNotifier.notify).toHaveBeenCalledTimes(1);
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.waitFor(() => {
+      expect(vi.mocked(mockSessionManager.list)).toHaveBeenCalledTimes(2);
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.waitFor(() => {
+      expect(vi.mocked(mockSessionManager.list)).toHaveBeenCalledTimes(3);
+    });
+
+    lm.stop();
+
+    const expectedIdempotencyKey = computeEventIdempotencyKey(
+      "app-1",
+      "merge.completed",
+      "approved",
+      "merged",
+      transitionTime,
+    );
+
+    expect(mockNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(mockNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "merge.completed",
+        idempotencyKey: expectedIdempotencyKey,
+      }),
+    );
+    expect(getLifecycleLogs()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "notification.deduplicated",
+          eventType: "merge.completed",
+          idempotencyKey: expectedIdempotencyKey,
+        }),
+      ]),
     );
   });
 
@@ -1391,6 +1525,10 @@ describe("reactions", () => {
   });
 
   it("auto-merges approved PRs with the default squash method", async () => {
+    vi.useFakeTimers();
+    const transitionTime = new Date("2026-03-09T12:00:00.000Z");
+    vi.setSystemTime(transitionTime);
+
     config.reactions = {
       "approved-and-green": {
         auto: true,
@@ -1486,12 +1624,39 @@ describe("reactions", () => {
       "app-1",
       expect.objectContaining({ onStep: expect.any(Function) }),
     );
+    expect(mockNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "merge.completed",
+        priority: "action",
+        idempotencyKey: computeEventIdempotencyKey(
+          "app-1",
+          "merge.ready",
+          "pr_open",
+          "mergeable",
+          transitionTime,
+        ),
+      }),
+    );
     expect(lm.getStates().has("app-1")).toBe(false);
     expect(readMetadataRaw(sessionsDir, "app-1")).toBeNull();
     expect(vi.mocked(mockNotifier.notify).mock.calls.map(([event]) => event.type)).toEqual([
       "merge.completed",
-      "session.completed",
     ]);
+    expect(getLifecycleLogs()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "notification.deduplicated",
+          eventType: "session.completed",
+          idempotencyKey: computeEventIdempotencyKey(
+            "app-1",
+            "merge.ready",
+            "pr_open",
+            "mergeable",
+            transitionTime,
+          ),
+        }),
+      ]),
+    );
   });
 
   it("force-cleans the worktree and branch after merge when session kill reports cleanup failures", async () => {
@@ -1611,17 +1776,26 @@ describe("reactions", () => {
     expect(lm.getStates().has("app-1")).toBe(false);
     expect(vi.mocked(mockNotifier.notify).mock.calls.map(([event]) => event.type)).toEqual([
       "merge.completed",
-      "session.completed",
     ]);
-
-    const completedEvent = vi
-      .mocked(mockNotifier.notify)
-      .mock.calls.map(([event]) => event)
-      .find((event) => event.type === "session.completed");
-    expect(completedEvent?.data["fallbackApplied"]).toBe(true);
+    expect(getLifecycleLogs()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "reaction.auto_merge.cleanup.completed",
+          fallbackApplied: true,
+        }),
+        expect.objectContaining({
+          event: "notification.deduplicated",
+          eventType: "session.completed",
+        }),
+      ]),
+    );
   });
 
   it("sends an urgent notification when auto-merge fails", async () => {
+    vi.useFakeTimers();
+    const transitionTime = new Date("2026-03-09T12:05:00.000Z");
+    vi.setSystemTime(transitionTime);
+
     config.reactions = {
       "approved-and-green": {
         auto: true,
@@ -1695,6 +1869,13 @@ describe("reactions", () => {
       expect.objectContaining({
         type: "reaction.triggered",
         priority: "urgent",
+        idempotencyKey: computeEventIdempotencyKey(
+          "app-1",
+          "merge.ready",
+          "pr_open",
+          "mergeable",
+          transitionTime,
+        ),
         message: expect.stringContaining("Auto-merge failed"),
       }),
     );

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -10,7 +10,7 @@
  * Reference: scripts/claude-session-status, scripts/claude-review-check
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   SESSION_STATUS,
   PR_STATE,
@@ -80,6 +80,81 @@ function inferPriority(type: EventType): EventPriority {
   return "info";
 }
 
+const EVENT_IDEMPOTENCY_BUCKET_MS = 60_000;
+const RECENT_EVENT_TTL_MS = 120_000;
+
+interface EventIdempotencySeed {
+  transition: string;
+  oldStatus?: SessionStatus;
+  newStatus?: SessionStatus;
+  timestamp?: Date;
+}
+
+interface TransitionEventContext {
+  idempotencyKey: string;
+  transition: EventType;
+  oldStatus: SessionStatus;
+  newStatus: SessionStatus;
+  timestamp: Date;
+}
+
+function getIdempotencyBucket(timestamp: Date): number {
+  return Math.floor(timestamp.getTime() / EVENT_IDEMPOTENCY_BUCKET_MS);
+}
+
+function defaultIdempotencyTransition(
+  type: EventType,
+  data: Record<string, unknown>,
+): string {
+  if (Object.keys(data).length === 0) {
+    return type;
+  }
+
+  return `${type}:${JSON.stringify(data)}`;
+}
+
+function createIdempotencyKey(opts: {
+  sessionId: SessionId;
+  transition: string;
+  oldStatus?: SessionStatus;
+  newStatus?: SessionStatus;
+  timestamp: Date;
+}): string {
+  return createHash("sha256")
+    .update(
+      [
+        opts.sessionId,
+        opts.transition,
+        opts.oldStatus ?? "",
+        opts.newStatus ?? "",
+        String(getIdempotencyBucket(opts.timestamp)),
+      ].join(":"),
+    )
+    .digest("hex");
+}
+
+function createTransitionEventContext(
+  sessionId: SessionId,
+  transition: EventType,
+  oldStatus: SessionStatus,
+  newStatus: SessionStatus,
+  timestamp = new Date(),
+): TransitionEventContext {
+  return {
+    idempotencyKey: createIdempotencyKey({
+      sessionId,
+      transition,
+      oldStatus,
+      newStatus,
+      timestamp,
+    }),
+    transition,
+    oldStatus,
+    newStatus,
+    timestamp,
+  };
+}
+
 /** Create an OrchestratorEvent with defaults filled in. */
 function createEvent(
   type: EventType,
@@ -89,17 +164,34 @@ function createEvent(
     message: string;
     priority?: EventPriority;
     data?: Record<string, unknown>;
+    idempotencyKey?: string;
+    idempotencySeed?: EventIdempotencySeed;
+    timestamp?: Date;
   },
 ): OrchestratorEvent {
+  const data = opts.data ?? {};
+  const timestamp = opts.timestamp ?? opts.idempotencySeed?.timestamp ?? new Date();
+  const transition =
+    opts.idempotencySeed?.transition ?? defaultIdempotencyTransition(type, data);
+
   return {
     id: randomUUID(),
+    idempotencyKey:
+      opts.idempotencyKey ??
+      createIdempotencyKey({
+        sessionId: opts.sessionId,
+        transition,
+        oldStatus: opts.idempotencySeed?.oldStatus,
+        newStatus: opts.idempotencySeed?.newStatus,
+        timestamp,
+      }),
     type,
     priority: opts.priority ?? inferPriority(type),
     sessionId: opts.sessionId,
     projectId: opts.projectId,
-    timestamp: new Date(),
+    timestamp,
     message: opts.message,
-    data: opts.data ?? {},
+    data,
   };
 }
 
@@ -366,9 +458,18 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
   const states = new Map<SessionId, SessionStatus>();
   const reactionTrackers = new Map<string, ReactionTracker>(); // "sessionId:reactionKey"
+  const recentEventIdempotencyKeys = new Map<string, number>();
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let polling = false; // re-entrancy guard
   let allCompleteEmitted = false; // guard against repeated all_complete
+
+  function pruneRecentEventIdempotencyKeys(nowMs = Date.now()): void {
+    for (const [key, expiresAtMs] of recentEventIdempotencyKeys.entries()) {
+      if (expiresAtMs <= nowMs) {
+        recentEventIdempotencyKeys.delete(key);
+      }
+    }
+  }
 
   function getOrCreateReactionTracker(sessionId: SessionId, reactionKey: string): ReactionTracker {
     const trackerKey = `${sessionId}:${reactionKey}`;
@@ -960,6 +1061,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     reactionConfig: ReactionConfig,
     pollStats?: LifecyclePollStats,
     session?: Session,
+    transitionContext?: TransitionEventContext,
   ): Promise<ReactionResult> {
     const tracker = getOrCreateReactionTracker(sessionId, reactionKey);
     const nowMs = Date.now();
@@ -997,6 +1099,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         projectId,
         message: `Reaction '${reactionKey}' escalated after ${tracker.attempts} attempts`,
         data: { reactionKey, attempts: tracker.attempts },
+        idempotencyKey: transitionContext?.idempotencyKey,
       });
       logLifecycle("info", "reaction.escalated", {
         pollId: pollStats?.pollId,
@@ -1074,6 +1177,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           projectId,
           message: `Reaction '${reactionKey}' triggered notification`,
           data: { reactionKey },
+          idempotencyKey: transitionContext?.idempotencyKey,
         });
         await notifyHuman(event, reactionConfig.priority ?? "info", pollStats);
         return {
@@ -1106,6 +1210,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             projectId,
             message: `Auto-merge could not run for reaction '${reactionKey}'. Manual intervention required.`,
             data: { reactionKey, mergeMethod },
+            idempotencyKey: transitionContext?.idempotencyKey,
           });
           await notifyHuman(event, "urgent", pollStats);
           return {
@@ -1142,6 +1247,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
               mergeMethod,
               error: message,
             },
+            idempotencyKey: transitionContext?.idempotencyKey,
           });
           await notifyHuman(event, "urgent", pollStats);
           return {
@@ -1172,6 +1278,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             prUrl: session.pr.url,
             mergeMethod,
           },
+          idempotencyKey: transitionContext?.idempotencyKey,
         });
         await notifyHuman(mergedEvent, inferPriority(mergedEvent.type), pollStats);
 
@@ -1202,6 +1309,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
               fallbackApplied: cleanup.fallbackApplied,
               error: cleanup.message,
             },
+            idempotencyKey: transitionContext?.idempotencyKey,
           });
           await notifyHuman(event, "urgent", pollStats);
           return {
@@ -1225,6 +1333,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             cleanupSteps: cleanup.steps,
             fallbackApplied: cleanup.fallbackApplied,
           },
+          idempotencyKey: transitionContext?.idempotencyKey,
         });
         await notifyHuman(completedEvent, inferPriority(completedEvent.type), pollStats);
         return {
@@ -1486,6 +1595,22 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       return;
     }
 
+    const nowMs = Date.now();
+    pruneRecentEventIdempotencyKeys(nowMs);
+    const existingTtl = recentEventIdempotencyKeys.get(event.idempotencyKey);
+    if (existingTtl !== undefined && existingTtl > nowMs) {
+      logLifecycle("info", "notification.deduplicated", {
+        pollId: pollStats?.pollId,
+        projectId: event.projectId,
+        sessionId: event.sessionId,
+        priority,
+        eventType: event.type,
+        idempotencyKey: event.idempotencyKey,
+      });
+      return;
+    }
+    recentEventIdempotencyKeys.set(event.idempotencyKey, nowMs + RECENT_EVENT_TTL_MS);
+
     for (const name of notifierNames) {
       const notifier = registry.get<Notifier>("notifier", name);
       if (!notifier) {
@@ -1516,6 +1641,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           notifier: name,
           priority,
           eventType: event.type,
+          idempotencyKey: event.idempotencyKey,
         });
       } catch (error) {
         incrementPollError(pollStats);
@@ -1529,6 +1655,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           notifier: name,
           priority,
           eventType: event.type,
+          idempotencyKey: event.idempotencyKey,
           error,
         });
       }
@@ -1583,6 +1710,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
       // Handle transition: notify humans and/or trigger reactions
       if (eventType) {
+        const transitionContext = createTransitionEventContext(
+          session.id,
+          eventType,
+          oldStatus,
+          newStatus,
+        );
         let reactionHandledNotify = false;
 
         if (reactionKey) {
@@ -1598,6 +1731,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
                 reactionConfig,
                 pollStats,
                 session,
+                transitionContext,
               );
               transitionReaction = { key: reactionKey, result: reactionResult };
 
@@ -1648,6 +1782,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             projectId: session.projectId,
             message: `${session.id}: ${oldStatus} → ${newStatus}`,
             data: { oldStatus, newStatus },
+            idempotencyKey: transitionContext.idempotencyKey,
+            timestamp: transitionContext.timestamp,
           });
           await notifyHuman(event, priority, pollStats);
         }
@@ -1680,6 +1816,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
     polling = true;
     const pollStats = createPollStats();
+    pruneRecentEventIdempotencyKeys();
 
     logLifecycle("info", "poll.start", {
       pollId: pollStats.pollId,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -806,6 +806,7 @@ export type EventType =
 /** An event emitted by the orchestrator */
 export interface OrchestratorEvent {
   id: string;
+  idempotencyKey: string;
   type: EventType;
   priority: EventPriority;
   sessionId: SessionId;

--- a/packages/integration-tests/src/helpers/event-factory.ts
+++ b/packages/integration-tests/src/helpers/event-factory.ts
@@ -14,6 +14,7 @@ import type {
 export function makeEvent(overrides: Partial<OrchestratorEvent> = {}): OrchestratorEvent {
   return {
     id: "evt-test-1",
+    idempotencyKey: "idem-evt-test-1",
     type: "session.spawned" as EventType,
     priority: "info" as EventPriority,
     sessionId: "app-1",

--- a/packages/integration-tests/src/notifier-webhook.integration.test.ts
+++ b/packages/integration-tests/src/notifier-webhook.integration.test.ts
@@ -37,6 +37,7 @@ describe("notifier-webhook integration", () => {
       const body = JSON.parse(fetchMock.mock.calls[0][1].body);
       expect(body.type).toBe("notification");
       expect(body.event.id).toBe("evt-test-1");
+      expect(body.event.idempotencyKey).toBe("idem-evt-test-1");
       expect(body.event.type).toBe("ci.failing");
       expect(body.event.priority).toBe("action");
       expect(body.event.sessionId).toBe("app-1");

--- a/packages/plugins/notifier-composio/src/index.test.ts
+++ b/packages/plugins/notifier-composio/src/index.test.ts
@@ -5,6 +5,7 @@ import { manifest, create } from "./index.js";
 function makeEvent(overrides: Partial<OrchestratorEvent> = {}): OrchestratorEvent {
   return {
     id: "evt-1",
+    idempotencyKey: "idem-evt-1",
     type: "session.spawned",
     priority: "info",
     sessionId: "app-1",

--- a/packages/plugins/notifier-desktop/src/index.test.ts
+++ b/packages/plugins/notifier-desktop/src/index.test.ts
@@ -21,6 +21,7 @@ const mockPlatform = platform as unknown as Mock;
 function makeEvent(overrides: Partial<OrchestratorEvent> = {}): OrchestratorEvent {
   return {
     id: "evt-1",
+    idempotencyKey: "idem-evt-1",
     type: "session.spawned",
     priority: "info",
     sessionId: "app-1",

--- a/packages/plugins/notifier-slack/src/index.test.ts
+++ b/packages/plugins/notifier-slack/src/index.test.ts
@@ -5,6 +5,7 @@ import { manifest, create } from "./index.js";
 function makeEvent(overrides: Partial<OrchestratorEvent> = {}): OrchestratorEvent {
   return {
     id: "evt-1",
+    idempotencyKey: "idem-evt-1",
     type: "session.spawned",
     priority: "info",
     sessionId: "app-1",

--- a/packages/plugins/notifier-webhook/src/index.test.ts
+++ b/packages/plugins/notifier-webhook/src/index.test.ts
@@ -5,6 +5,7 @@ import { manifest, create } from "./index.js";
 function makeEvent(overrides: Partial<OrchestratorEvent> = {}): OrchestratorEvent {
   return {
     id: "evt-1",
+    idempotencyKey: "idem-evt-1",
     type: "ci.failing",
     priority: "action",
     sessionId: "app-1",
@@ -88,6 +89,7 @@ describe("notifier-webhook", () => {
       const body = JSON.parse(opts.body);
       expect(body.type).toBe("notification");
       expect(body.event.id).toBe("evt-1");
+      expect(body.event.idempotencyKey).toBe("idem-evt-1");
       expect(body.event.sessionId).toBe("app-1");
       expect(body.event.type).toBe("ci.failing");
     });

--- a/packages/plugins/notifier-webhook/src/index.ts
+++ b/packages/plugins/notifier-webhook/src/index.ts
@@ -18,6 +18,7 @@ interface WebhookPayload {
   type: "notification" | "notification_with_actions" | "message";
   event?: {
     id: string;
+    idempotencyKey: string;
     type: string;
     priority: string;
     sessionId: string;
@@ -91,6 +92,7 @@ async function postWithRetry(
 function serializeEvent(event: OrchestratorEvent): WebhookPayload["event"] {
   return {
     id: event.id,
+    idempotencyKey: event.idempotencyKey,
     type: event.type,
     priority: event.priority,
     sessionId: event.sessionId,


### PR DESCRIPTION
## Summary
- add deterministic idempotency keys to orchestrator events and reuse transition keys for reaction-driven notifications
- deduplicate lifecycle notifications for recently emitted transition keys before dispatching to notifiers
- expose idempotency keys in notifier-webhook payloads and cover the behavior with lifecycle and webhook tests

Closes #10