### PR TITLE
fix(lifecycle): clean up auto-merged sessions after merge

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { execFileSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { createLifecycleManager } from "../lifecycle-manager.js";
 import { createSessionManager } from "../session-manager.js";
-import { writeMetadata, readMetadataRaw } from "../metadata.js";
-import { getSessionsDir, getProjectBaseDir } from "../paths.js";
+import { deleteMetadata, writeMetadata, readMetadataRaw } from "../metadata.js";
+import { getSessionsDir, getProjectBaseDir, getWorktreesDir } from "../paths.js";
 import type {
   OrchestratorConfig,
   PluginRegistry,
@@ -76,6 +77,10 @@ function getLifecycleLogs(): Array<Record<string, unknown>> {
       return [];
     }
   });
+}
+
+function runGit(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf-8" }).trim();
 }
 
 beforeEach(() => {
@@ -303,7 +308,7 @@ describe("poll logging", () => {
       }),
     };
 
-    const session = makeSession({ status: "pr_open", pr: makePR() });
+    const session = makeSession({ status: "pr_open", pr: makePR(), branch: "feat/test" });
     vi.mocked(mockSessionManager.list).mockResolvedValue([session]);
 
     writeMetadata(sessionsDir, "app-1", {
@@ -1432,10 +1437,38 @@ describe("reactions", () => {
 
     const session = makeSession({ status: "pr_open", pr: makePR() });
     vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    vi.mocked(mockSessionManager.kill).mockImplementation(async (_sessionId, options) => {
+      options?.onStep?.({
+        step: "runtime",
+        status: "success",
+        message: "Stopped mock runtime rt-1",
+      });
+      options?.onStep?.({
+        step: "agent",
+        status: "success",
+        message: "Session process tree already stopped",
+      });
+      options?.onStep?.({
+        step: "worktree",
+        status: "success",
+        message: "Removed worktree /tmp",
+      });
+      options?.onStep?.({
+        step: "branch",
+        status: "success",
+        message: "Local branch feat/test already absent",
+      });
+      deleteMetadata(sessionsDir, "app-1", true);
+      options?.onStep?.({
+        step: "metadata",
+        status: "success",
+        message: "Archived metadata for app-1",
+      });
+    });
 
     writeMetadata(sessionsDir, "app-1", {
       worktree: "/tmp",
-      branch: "main",
+      branch: "feat/test",
       status: "pr_open",
       project: "my-app",
     });
@@ -1449,11 +1482,143 @@ describe("reactions", () => {
     await lm.check("app-1");
 
     expect(mockSCM.mergePR).toHaveBeenCalledWith(session.pr, "squash");
-    expect(lm.getStates().get("app-1")).toBe("merged");
-    expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("merged");
-    expect(mockNotifier.notify).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "merge.completed", priority: "action" }),
+    expect(mockSessionManager.kill).toHaveBeenCalledWith(
+      "app-1",
+      expect.objectContaining({ onStep: expect.any(Function) }),
     );
+    expect(lm.getStates().has("app-1")).toBe(false);
+    expect(readMetadataRaw(sessionsDir, "app-1")).toBeNull();
+    expect(vi.mocked(mockNotifier.notify).mock.calls.map(([event]) => event.type)).toEqual([
+      "merge.completed",
+      "session.completed",
+    ]);
+  });
+
+  it("force-cleans the worktree and branch after merge when session kill reports cleanup failures", async () => {
+    config.reactions = {
+      "approved-and-green": {
+        auto: true,
+        action: "auto-merge",
+      },
+    };
+    config.projects["my-app"]!.workspace = "worktree";
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn().mockResolvedValue(undefined),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("approved"),
+      getPendingComments: vi.fn().mockResolvedValue([]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: true,
+        ciPassing: true,
+        approved: true,
+        noConflicts: true,
+        blockers: [],
+      }),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const repoPath = config.projects["my-app"]!.path;
+    mkdirSync(repoPath, { recursive: true });
+    runGit(repoPath, "init", "-b", "main");
+    runGit(repoPath, "config", "user.email", "ao@example.com");
+    runGit(repoPath, "config", "user.name", "AO Test");
+    writeFileSync(join(repoPath, "README.md"), "hello\n", "utf-8");
+    runGit(repoPath, "add", "README.md");
+    runGit(repoPath, "commit", "-m", "init");
+
+    const managedWorktree = join(getWorktreesDir(config.configPath, repoPath), "app-1");
+    mkdirSync(join(getWorktreesDir(config.configPath, repoPath)), { recursive: true });
+    runGit(repoPath, "worktree", "add", "-b", "feat/test", managedWorktree, "HEAD");
+
+    const session = makeSession({
+      status: "pr_open",
+      pr: makePR(),
+      branch: "feat/test",
+      workspacePath: managedWorktree,
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    vi.mocked(mockSessionManager.kill).mockImplementation(async (_sessionId, options) => {
+      options?.onStep?.({
+        step: "runtime",
+        status: "failed",
+        message: "Failed to stop process runtime proc-1",
+      });
+      options?.onStep?.({
+        step: "agent",
+        status: "success",
+        message: "Stopped session process tree (1 process)",
+      });
+      options?.onStep?.({
+        step: "worktree",
+        status: "failed",
+        message: `Failed to remove worktree ${managedWorktree}: directory still exists`,
+      });
+      options?.onStep?.({
+        step: "branch",
+        status: "failed",
+        message: "Failed to delete local branch feat/test: branch is checked out",
+      });
+      deleteMetadata(sessionsDir, "app-1", true);
+      options?.onStep?.({
+        step: "metadata",
+        status: "success",
+        message: "Archived metadata for app-1",
+      });
+      throw new Error("cleanup completed with failures");
+    });
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: managedWorktree,
+      branch: "feat/test",
+      status: "pr_open",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(existsSync(managedWorktree)).toBe(false);
+    expect(runGit(repoPath, "branch", "--list", "feat/test")).toBe("");
+    expect(readMetadataRaw(sessionsDir, "app-1")).toBeNull();
+    expect(lm.getStates().has("app-1")).toBe(false);
+    expect(vi.mocked(mockNotifier.notify).mock.calls.map(([event]) => event.type)).toEqual([
+      "merge.completed",
+      "session.completed",
+    ]);
+
+    const completedEvent = vi
+      .mocked(mockNotifier.notify)
+      .mock.calls.map(([event]) => event)
+      .find((event) => event.type === "session.completed");
+    expect(completedEvent?.data["fallbackApplied"]).toBe(true);
   });
 
   it("sends an urgent notification when auto-merge fails", async () => {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -33,10 +33,13 @@ import {
   type Notifier,
   type Session,
   type EventPriority,
+  type SessionKillStep,
+  type SessionKillStepResult,
   type ProjectConfig as _ProjectConfig,
 } from "./types.js";
 import { updateMetadata } from "./metadata.js";
 import { getSessionsDir } from "./paths.js";
+import { deleteLocalBranch, forceRemoveGitWorktree } from "./session-manager.js";
 
 /** Parse a duration string like "10m", "30s", "1h" to milliseconds. */
 function parseDuration(str: string): number {
@@ -322,6 +325,39 @@ function getReactionRefireIntervalMs(
   }
 
   return DEFAULT_REACTION_REFIRE_INTERVAL_MS;
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function upsertKillStep(
+  steps: Map<SessionKillStep, SessionKillStepResult>,
+  result: SessionKillStepResult,
+): void {
+  steps.set(result.step, result);
+}
+
+function listKillSteps(
+  steps: Map<SessionKillStep, SessionKillStepResult>,
+): SessionKillStepResult[] {
+  return [...steps.values()];
+}
+
+function isSessionCleanupComplete(
+  steps: Map<SessionKillStep, SessionKillStepResult>,
+): boolean {
+  const metadata = steps.get("metadata");
+  if (!metadata || metadata.status !== "success") {
+    return false;
+  }
+
+  return !listKillSteps(steps).some(
+    (step) =>
+      step.status === "failed" &&
+      step.step !== "runtime" &&
+      step.step !== "opencode",
+  );
 }
 
 /** Create a LifecycleManager instance. */
@@ -741,6 +777,181 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     return currentStatus;
   }
 
+  async function cleanupMergedSession(
+    session: Session,
+    reactionKey: string,
+    mergeMethod: string,
+    pollStats?: LifecyclePollStats,
+  ): Promise<{
+    success: boolean;
+    message: string;
+    steps: SessionKillStepResult[];
+    fallbackApplied: boolean;
+  }> {
+    const project = config.projects[session.projectId];
+    if (!project) {
+      return {
+        success: false,
+        message: `Unknown project ${session.projectId}`,
+        steps: [],
+        fallbackApplied: false,
+      };
+    }
+
+    const steps = new Map<SessionKillStep, SessionKillStepResult>();
+    const usesGitWorktreeCleanup = (project.workspace ?? config.defaults.workspace) === "worktree";
+    let fallbackApplied = false;
+    let killError: string | null = null;
+
+    try {
+      await sessionManager.kill(session.id, {
+        onStep: (result) => upsertKillStep(steps, result),
+      });
+    } catch (error) {
+      killError = formatErrorMessage(error);
+      logLifecycle("error", "reaction.auto_merge.cleanup.kill_failed", {
+        pollId: pollStats?.pollId,
+        projectId: session.projectId,
+        sessionId: session.id,
+        reactionKey,
+        error,
+        cleanupSteps: listKillSteps(steps),
+      });
+    }
+
+    const worktreeStep = steps.get("worktree");
+    if (
+      usesGitWorktreeCleanup &&
+      session.workspacePath &&
+      worktreeStep?.status !== "success" &&
+      worktreeStep?.status !== "skipped"
+    ) {
+      try {
+        await forceRemoveGitWorktree(project.path, session.workspacePath);
+        fallbackApplied = true;
+        upsertKillStep(steps, {
+          step: "worktree",
+          status: "success",
+          message: `Removed worktree ${session.workspacePath} via auto-merge fallback`,
+        });
+        logLifecycle("info", "reaction.auto_merge.cleanup.worktree_fallback.completed", {
+          pollId: pollStats?.pollId,
+          projectId: session.projectId,
+          sessionId: session.id,
+          reactionKey,
+          worktree: session.workspacePath,
+        });
+      } catch (error) {
+        upsertKillStep(steps, {
+          step: "worktree",
+          status: "failed",
+          message: [
+            worktreeStep?.message,
+            `Auto-merge fallback failed: ${formatErrorMessage(error)}`,
+          ]
+            .filter(Boolean)
+            .join("; "),
+        });
+        logLifecycle("error", "reaction.auto_merge.cleanup.worktree_fallback.failed", {
+          pollId: pollStats?.pollId,
+          projectId: session.projectId,
+          sessionId: session.id,
+          reactionKey,
+          worktree: session.workspacePath,
+          error,
+        });
+      }
+    }
+
+    const branchStep = steps.get("branch");
+    if (
+      usesGitWorktreeCleanup &&
+      session.branch &&
+      session.branch !== project.defaultBranch &&
+      branchStep?.status !== "success" &&
+      branchStep?.status !== "skipped"
+    ) {
+      try {
+        const branchResult = await deleteLocalBranch(project.path, session.branch);
+        fallbackApplied = true;
+        upsertKillStep(steps, {
+          step: "branch",
+          status: "success",
+          message:
+            branchResult === "deleted"
+              ? `Deleted local branch ${session.branch} via auto-merge fallback`
+              : `Local branch ${session.branch} already absent via auto-merge fallback`,
+        });
+        logLifecycle("info", "reaction.auto_merge.cleanup.branch_fallback.completed", {
+          pollId: pollStats?.pollId,
+          projectId: session.projectId,
+          sessionId: session.id,
+          reactionKey,
+          branch: session.branch,
+          branchResult,
+        });
+      } catch (error) {
+        upsertKillStep(steps, {
+          step: "branch",
+          status: "failed",
+          message: [
+            branchStep?.message,
+            `Auto-merge fallback failed: ${formatErrorMessage(error)}`,
+          ]
+            .filter(Boolean)
+            .join("; "),
+        });
+        logLifecycle("error", "reaction.auto_merge.cleanup.branch_fallback.failed", {
+          pollId: pollStats?.pollId,
+          projectId: session.projectId,
+          sessionId: session.id,
+          reactionKey,
+          branch: session.branch,
+          error,
+        });
+      }
+    }
+
+    const finalSteps = listKillSteps(steps);
+    if (isSessionCleanupComplete(steps)) {
+      states.delete(session.id);
+      logLifecycle("info", "reaction.auto_merge.cleanup.completed", {
+        pollId: pollStats?.pollId,
+        projectId: session.projectId,
+        sessionId: session.id,
+        reactionKey,
+        mergeMethod,
+        fallbackApplied,
+        cleanupSteps: finalSteps,
+      });
+      return {
+        success: true,
+        message: killError
+          ? `Merged PR and completed session cleanup after recovery: ${killError}`
+          : "Merged PR and completed session cleanup",
+        steps: finalSteps,
+        fallbackApplied,
+      };
+    }
+
+    const blockingFailureMessage = finalSteps
+      .filter(
+        (step) =>
+          step.status === "failed" &&
+          step.step !== "runtime" &&
+          step.step !== "opencode",
+      )
+      .map((step) => `${step.step}: ${step.message}`)
+      .join("; ");
+
+    return {
+      success: false,
+      message: (killError ?? blockingFailureMessage) || "Session cleanup incomplete",
+      steps: finalSteps,
+      fallbackApplied,
+    };
+  }
+
   /** Execute a reaction for a session. */
   async function executeReaction(
     sessionId: SessionId,
@@ -908,35 +1119,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
         try {
           await scm.mergePR(session.pr, mergeMethod);
-          clearReactionTracker(session.id, reactionKey);
-          logLifecycle("info", "reaction.auto_merge.completed", {
-            pollId: pollStats?.pollId,
-            projectId,
-            sessionId,
-            reactionKey,
-            prNumber: session.pr.number,
-            mergeMethod,
-          });
-          const event = createEvent("merge.completed", {
-            sessionId,
-            projectId,
-            message: `${sessionId}: auto-merged PR #${session.pr.number}`,
-            data: {
-              reactionKey,
-              prNumber: session.pr.number,
-              prUrl: session.pr.url,
-              mergeMethod,
-            },
-          });
-          await notifyHuman(event, inferPriority(event.type), pollStats);
-          return {
-            reactionType: reactionKey,
-            success: true,
-            action: "auto-merge",
-            message: `Merged PR #${session.pr.number} with ${mergeMethod}`,
-            escalated: false,
-            resultingStatus: SESSION_STATUS.MERGED,
-          };
         } catch (error) {
           incrementPollError(pollStats);
           logLifecycle("error", "reaction.auto_merge.failed", {
@@ -970,6 +1152,88 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             escalated: true,
           };
         }
+
+        clearReactionTracker(session.id, reactionKey);
+        logLifecycle("info", "reaction.auto_merge.completed", {
+          pollId: pollStats?.pollId,
+          projectId,
+          sessionId,
+          reactionKey,
+          prNumber: session.pr.number,
+          mergeMethod,
+        });
+        const mergedEvent = createEvent("merge.completed", {
+          sessionId,
+          projectId,
+          message: `${sessionId}: auto-merged PR #${session.pr.number}`,
+          data: {
+            reactionKey,
+            prNumber: session.pr.number,
+            prUrl: session.pr.url,
+            mergeMethod,
+          },
+        });
+        await notifyHuman(mergedEvent, inferPriority(mergedEvent.type), pollStats);
+
+        const cleanup = await cleanupMergedSession(session, reactionKey, mergeMethod, pollStats);
+        if (!cleanup.success) {
+          incrementPollError(pollStats);
+          logLifecycle("error", "reaction.auto_merge.cleanup.incomplete", {
+            pollId: pollStats?.pollId,
+            projectId,
+            sessionId,
+            reactionKey,
+            prNumber: session.pr.number,
+            mergeMethod,
+            fallbackApplied: cleanup.fallbackApplied,
+            cleanupSteps: cleanup.steps,
+            cleanupError: cleanup.message,
+          });
+          const event = createEvent("reaction.triggered", {
+            sessionId,
+            projectId,
+            message: `Auto-merge cleanup failed after PR #${session.pr.number} merged. Manual intervention required.`,
+            data: {
+              reactionKey,
+              prNumber: session.pr.number,
+              prUrl: session.pr.url,
+              mergeMethod,
+              cleanupSteps: cleanup.steps,
+              fallbackApplied: cleanup.fallbackApplied,
+              error: cleanup.message,
+            },
+          });
+          await notifyHuman(event, "urgent", pollStats);
+          return {
+            reactionType: reactionKey,
+            success: false,
+            action: "auto-merge",
+            message: cleanup.message,
+            escalated: true,
+          };
+        }
+
+        const completedEvent = createEvent("session.completed", {
+          sessionId,
+          projectId,
+          message: `${sessionId}: session cleanup completed after auto-merge of PR #${session.pr.number}`,
+          data: {
+            reactionKey,
+            prNumber: session.pr.number,
+            prUrl: session.pr.url,
+            mergeMethod,
+            cleanupSteps: cleanup.steps,
+            fallbackApplied: cleanup.fallbackApplied,
+          },
+        });
+        await notifyHuman(completedEvent, inferPriority(completedEvent.type), pollStats);
+        return {
+          reactionType: reactionKey,
+          success: true,
+          action: "auto-merge",
+          message: `Merged PR #${session.pr.number} with ${mergeMethod} and cleaned up session`,
+          escalated: false,
+        };
       }
     }
 
@@ -1391,6 +1655,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     } else {
       // No transition but track current state
       states.set(session.id, newStatus);
+    }
+
+    if (!states.has(session.id)) {
+      return;
     }
 
     await maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction, pollStats);

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -313,7 +313,10 @@ async function isGitWorktreeRegistered(repoPath: string, workspacePath: string):
   });
 }
 
-async function forceRemoveGitWorktree(repoPath: string, workspacePath: string): Promise<void> {
+export async function forceRemoveGitWorktree(
+  repoPath: string,
+  workspacePath: string,
+): Promise<void> {
   try {
     await execFileAsync("git", ["worktree", "remove", "--force", workspacePath], {
       cwd: repoPath,
@@ -350,7 +353,10 @@ async function forceRemoveGitWorktree(repoPath: string, workspacePath: string): 
   }
 }
 
-async function deleteLocalBranch(repoPath: string, branch: string): Promise<"deleted" | "missing"> {
+export async function deleteLocalBranch(
+  repoPath: string,
+  branch: string,
+): Promise<"deleted" | "missing"> {
   if (!(await gitBranchExists(repoPath, branch))) {
     return "missing";
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -768,6 +768,7 @@ export type EventType =
   // Session lifecycle
   | "session.spawned"
   | "session.working"
+  | "session.completed"
   | "session.exited"
   | "session.killed"
   | "session.stuck"


### PR DESCRIPTION
## Summary
- run session cleanup immediately after successful auto-merge instead of leaving the merged worktree/session behind
- emit a new session.completed event only after cleanup is fully done, with fallback worktree and branch cleanup when kill reports failures
- add lifecycle coverage for the normal cleanup path and the recovered fallback path

## Verification
- pnpm run build
- pnpm run typecheck
- pnpm test
- pnpm run lint

Closes #2