### PR TITLE
fix(agent-codex): match nested Codex session metadata

### DIFF
--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -126,14 +126,18 @@ function mockTmuxWithProcess(processName: string, found = true) {
 
 /**
  * Create a mock file handle for `open()` that returns `content` from `read()`.
- * Used by sessionFileMatchesCwd which reads only the first 4 KB.
+ * Used by sessionFileMatchesCwd which reads the JSONL header in chunks.
  */
 function makeFakeFileHandle(content: string) {
   const buf = Buffer.from(content, "utf-8");
   return {
-    read: vi.fn().mockImplementation((buffer: Buffer, offset: number, length: number, _position: number) => {
-      const bytesToCopy = Math.min(length, buf.length);
-      buf.copy(buffer, offset, 0, bytesToCopy);
+    read: vi.fn().mockImplementation((buffer: Buffer, offset: number, length: number, position: number | null) => {
+      const start = typeof position === "number" ? position : 0;
+      if (start >= buf.length) {
+        return Promise.resolve({ bytesRead: 0, buffer });
+      }
+      const bytesToCopy = Math.min(length, buf.length - start);
+      buf.copy(buffer, offset, start, start + bytesToCopy);
       return Promise.resolve({ bytesRead: bytesToCopy, buffer });
     }),
     close: vi.fn().mockResolvedValue(undefined),
@@ -657,7 +661,7 @@ describe("getActivityState", () => {
     expect(result?.timestamp).toBeInstanceOf(Date);
   });
 
-  it("matches session_meta cwd nested in payload", async () => {
+  it("returns active when session_meta cwd is nested under payload", async () => {
     mockTmuxWithProcess("codex");
     const content = '{"type":"session_meta","payload":{"cwd":"/workspace/test"}}\n';
     mockReaddir.mockResolvedValue(["sess.jsonl"]);
@@ -670,6 +674,21 @@ describe("getActivityState", () => {
     expect(result?.timestamp).toBeInstanceOf(Date);
   });
 
+  it("returns active when the session_meta header spans more than one read chunk", async () => {
+    mockTmuxWithProcess("codex");
+    const content = `${JSON.stringify({
+      type: "session_meta",
+      payload: { cwd: "/workspace/test", base_instructions: { text: "x".repeat(5000) } },
+    })}\n`;
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    const result = await agent.getActivityState(session);
+    expect(result?.state).toBe("active");
+    expect(result?.timestamp).toBeInstanceOf(Date);
+  });
   it("returns idle when session file is stale", async () => {
     mockTmuxWithProcess("codex");
     const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
@@ -762,7 +781,7 @@ describe("getSessionInfo", () => {
     expect(result!.cost!.estimatedCostUsd).toBeGreaterThan(0);
   });
 
-  it("matches session_meta cwd nested in payload for session discovery", async () => {
+  it("matches session files when session_meta cwd is nested under payload", async () => {
     const sessionContent = jsonl(
       { type: "session_meta", payload: { cwd: "/workspace/test" }, model: "gpt-4o" },
       { type: "event_msg", msg: { type: "token_count", input_tokens: 100, output_tokens: 50 } },

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -336,9 +336,6 @@ interface CodexJsonlLine {
   type?: string;
   cwd?: string;
   model?: string;
-  payload?: {
-    cwd?: string;
-  };
   // Thread ID from thread_started notifications
   threadId?: string;
   // User message content (from user input events)
@@ -346,7 +343,12 @@ interface CodexJsonlLine {
   role?: string;
   // event_msg with token_count subtype
   msg?: CodexEventMessage;
-  payload?: CodexEventMessage;
+  payload?: CodexJsonlPayload | null;
+}
+
+interface CodexJsonlPayload extends CodexEventMessage {
+  cwd?: string;
+  model?: string;
 }
 
 interface CodexTokenUsageTotals {
@@ -389,10 +391,6 @@ interface CodexEventMessage {
   output_tokens?: number;
   info?: CodexTokenUsageInfo | null;
   rate_limits?: CodexRateLimitSnapshot | CodexRateLimitSnapshot[] | null;
-}
-
-function getSessionMetaCwd(entry: CodexJsonlLine): string | undefined {
-  return entry.cwd ?? entry.payload?.cwd;
 }
 
 /**
@@ -440,22 +438,45 @@ async function collectJsonlFiles(dir: string, depth = 0): Promise<string[]> {
 
 /**
  * Check if the first few lines of a JSONL file contain a session_meta
- * entry matching the given workspace path. Reads only the first 4 KB
+ * entry matching the given workspace path. Reads only the JSONL header
  * to avoid loading large rollout files into memory.
  */
+const SESSION_FILE_MATCH_CHUNK_BYTES = 4096;
+const SESSION_FILE_MATCH_MAX_BYTES = 64 * 1024;
+const SESSION_FILE_MATCH_MAX_LINES = 10;
+
 async function sessionFileMatchesCwd(
   filePath: string,
   workspacePath: string,
 ): Promise<boolean> {
   try {
-    // Read only the first 4 KB — session_meta is always in the first few lines.
-    // Avoids loading large rollout files (100 MB+) into memory.
     const handle = await open(filePath, "r");
     let content: string;
     try {
-      const buffer = Buffer.allocUnsafe(4096);
-      const { bytesRead } = await handle.read(buffer, 0, 4096, 0);
-      content = buffer.subarray(0, bytesRead).toString("utf-8");
+      // session_meta is emitted near the top of the file, but can be larger
+      // than a single chunk when Codex embeds long instruction payloads.
+      const chunks: Buffer[] = [];
+      let totalBytes = 0;
+      let newlineCount = 0;
+
+      while (totalBytes < SESSION_FILE_MATCH_MAX_BYTES && newlineCount < SESSION_FILE_MATCH_MAX_LINES) {
+        const chunkSize = Math.min(SESSION_FILE_MATCH_CHUNK_BYTES, SESSION_FILE_MATCH_MAX_BYTES - totalBytes);
+        const buffer = Buffer.allocUnsafe(chunkSize);
+        const { bytesRead } = await handle.read(buffer, 0, chunkSize, totalBytes);
+        if (bytesRead === 0) break;
+
+        const chunk = buffer.subarray(0, bytesRead);
+        chunks.push(chunk);
+        totalBytes += bytesRead;
+
+        for (const byte of chunk) {
+          if (byte === 0x0a) newlineCount += 1;
+        }
+
+        if (bytesRead < chunkSize) break;
+      }
+
+      content = Buffer.concat(chunks, totalBytes).toString("utf-8");
     } finally {
       await handle.close();
     }
@@ -465,10 +486,12 @@ async function sessionFileMatchesCwd(
       if (!trimmed) continue;
       try {
         const parsed: unknown = JSON.parse(trimmed);
-        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) continue;
-
-        const entry = parsed as CodexJsonlLine;
-        if (entry.type === "session_meta" && getSessionMetaCwd(entry) === workspacePath) {
+        if (
+          typeof parsed === "object" &&
+          parsed !== null &&
+          !Array.isArray(parsed) &&
+          sessionMetaMatchesWorkspace(parsed as CodexJsonlLine, workspacePath)
+        ) {
           return true;
         }
       } catch {
@@ -479,6 +502,11 @@ async function sessionFileMatchesCwd(
     // Unreadable file
   }
   return false;
+}
+
+function sessionMetaMatchesWorkspace(entry: CodexJsonlLine, workspacePath: string): boolean {
+  if (entry.type !== "session_meta") return false;
+  return entry.cwd === workspacePath || entry.payload?.cwd === workspacePath;
 }
 
 /**


### PR DESCRIPTION
## Summary
- match Codex session files when session_meta stores the workspace cwd under payload.cwd
- keep session discovery working when the first session_meta line is larger than the initial 4 KB read chunk
- add regressions covering nested payload cwd matching and oversized session headers

## Validation
- pnpm run typecheck
- pnpm test
- pnpm run lint

Closes #404