### PR TITLE
fix: keep sessions alive while waiting for CI

### DIFF
--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -34,6 +34,7 @@ export function statusColor(status: string): string {
     case "idle":
       return chalk.yellow(status);
     case "pr_open":
+    case "waiting_ci":
     case "review_pending":
       return chalk.blue(status);
     case "approved":

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -62,7 +62,7 @@ Polls sessions, detects state changes, triggers reactions:
 **State machine:**
 
 ```
-spawning → working → pr_open → ci_failed/review_pending/approved → mergeable → merged
+spawning → working → pr_open → waiting_ci → ci_failed/review_pending/approved → mergeable → merged
 ```
 
 **Reactions:**

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { createLifecycleManager } from "../lifecycle-manager.js";
 import { createSessionManager } from "../session-manager.js";
-import { deleteMetadata, writeMetadata, readMetadataRaw } from "../metadata.js";
+import { deleteMetadata, writeMetadata, readMetadataRaw, updateMetadata } from "../metadata.js";
 import { getSessionsDir, getProjectBaseDir, getWorktreesDir } from "../paths.js";
 import type {
   OrchestratorConfig,
@@ -410,6 +410,124 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("killed");
   });
 
+  it("keeps PR sessions in waiting_ci when the runtime exits before CI finishes", async () => {
+    vi.mocked(mockRuntime.isAlive).mockResolvedValue(false);
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("pending"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: false,
+        ciPassing: false,
+        approved: false,
+        noConflicts: true,
+        blockers: ["ci"],
+      }),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+      pr: makePR().url,
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("waiting_ci");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("waiting_ci");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["waitingCiSince"]).toBeTruthy();
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["lastPrCiStatus"]).toBe("pending");
+  });
+
+  it("auto-detects the PR and enters waiting_ci when the agent exits before metadata is updated", async () => {
+    vi.mocked(mockRuntime.isAlive).mockResolvedValue(false);
+
+    const pr = makePR();
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn().mockResolvedValue(pr),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("pending"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: false,
+        ciPassing: false,
+        approved: false,
+        noConflicts: true,
+        blockers: ["ci"],
+      }),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "working", pr: null, branch: pr.branch });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: pr.branch,
+      status: "working",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(mockSCM.detectPR).toHaveBeenCalledWith(session, config.projects["my-app"]);
+    expect(lm.getStates().get("app-1")).toBe("waiting_ci");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["pr"]).toBe(pr.url);
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("waiting_ci");
+  });
+
   it("detects killed state when getActivityState returns exited", async () => {
     vi.mocked(mockAgent.getActivityState).mockResolvedValue({ state: "exited" });
 
@@ -724,6 +842,166 @@ describe("check (single session)", () => {
 
     expect(mockSCM.getCISummary).toHaveBeenCalledTimes(3);
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("wakes a waiting_ci session when CI later fails after the agent exits", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T10:00:00.000Z"));
+
+    config.reactions = {
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        message: "Fix CI",
+      },
+    };
+
+    vi.mocked(mockRuntime.isAlive).mockResolvedValue(false);
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValueOnce("pending").mockResolvedValueOnce("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: false,
+        ciPassing: false,
+        approved: false,
+        noConflicts: true,
+        blockers: ["ci"],
+      }),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+      pr: makePR().url,
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("waiting_ci");
+    expect(mockSessionManager.send).not.toHaveBeenCalled();
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["waitingCiSince"]).toBeTruthy();
+
+    vi.setSystemTime(new Date("2026-03-09T10:01:01.000Z"));
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("ci_failed");
+    expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "Fix CI");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("ci_failed");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["waitingCiSince"]).toBeUndefined();
+  });
+
+  it("times out waiting_ci sessions after 30 minutes and warns humans", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T10:31:00.000Z"));
+
+    config.notificationRouting.warning = ["desktop"];
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    vi.mocked(mockRuntime.isAlive).mockResolvedValue(false);
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("pending"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: false,
+        ciPassing: false,
+        approved: false,
+        noConflicts: true,
+        blockers: ["ci"],
+      }),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const session = makeSession({
+      status: "waiting_ci",
+      pr: makePR(),
+      metadata: { waitingCiSince: "2026-03-09T10:00:00.000Z" },
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "waiting_ci",
+      project: "my-app",
+      pr: makePR().url,
+    });
+    updateMetadata(sessionsDir, "app-1", {
+      waitingCiSince: "2026-03-09T10:00:00.000Z",
+      lastPrStatusPollAt: "2026-03-09T10:00:00.000Z",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("done");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("done");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["waitingCiTimedOutAt"]).toBeTruthy();
+    expect(mockNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "session.completed",
+        priority: "warning",
+      }),
+    );
   });
 
   it("promotes a stuck PR to mergeable when CI passes and no review is required", async () => {

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -1108,7 +1108,7 @@ describe("list", () => {
     vi.useRealTimers();
   });
 
-  it("marks dead runtimes as killed", async () => {
+  it("marks dead runtimes as exited without clobbering their status", async () => {
     const deadRuntime: Runtime = {
       ...mockRuntime,
       isAlive: vi.fn().mockResolvedValue(false),
@@ -1133,8 +1133,39 @@ describe("list", () => {
     const sm = createSessionManager({ config, registry: registryWithDead });
     const sessions = await sm.list();
 
-    expect(sessions[0].status).toBe("killed");
+    expect(sessions[0].status).toBe("working");
     expect(sessions[0].activity).toBe("exited");
+  });
+
+  it("preserves waiting_ci sessions after the agent exits", async () => {
+    const deadRuntime: Runtime = {
+      ...mockRuntime,
+      isAlive: vi.fn().mockResolvedValue(false),
+    };
+    const registryWithDead: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return deadRuntime;
+        if (slot === "agent") return mockAgent;
+        return null;
+      }),
+    };
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "a",
+      status: "waiting_ci",
+      project: "my-app",
+      pr: "https://github.com/org/repo/pull/42",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+
+    const sm = createSessionManager({ config, registry: registryWithDead });
+    const sessions = await sm.list();
+
+    expect(sessions[0].status).toBe("waiting_ci");
+    expect(sessions[0].activity).toBe("exited");
+    expect(deadRuntime.isAlive).not.toHaveBeenCalled();
   });
 
   it("detects activity using agent-native mechanism", async () => {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -269,6 +269,7 @@ function createPollStats(): LifecyclePollStats {
 }
 
 const OPEN_PR_STATUS_POLL_INTERVAL_MS = 60_000;
+const WAITING_CI_TIMEOUT_MS = 30 * 60_000;
 const DEFAULT_CI_REACTION_REFIRE_INTERVAL_MS = 120_000;
 const DEFAULT_REACTION_REFIRE_INTERVAL_MS = 300_000;
 
@@ -287,6 +288,46 @@ function isOpenPRStatusPollDue(session: Session): boolean {
   const lastPollAtMs = parseTimestampMs(session.metadata["lastPrStatusPollAt"]);
   if (lastPollAtMs === null) return true;
   return Date.now() - lastPollAtMs >= OPEN_PR_STATUS_POLL_INTERVAL_MS;
+}
+
+function isWaitingForCiVerdict(ciStatus: CIStatus): boolean {
+  return ciStatus === CI_STATUS.NONE || ciStatus === CI_STATUS.PENDING;
+}
+
+function shouldKeepPollingExitedPRSession(
+  session: Session,
+  currentStatus: SessionStatus,
+  allowPrAutoDetect: boolean,
+): boolean {
+  if (!session.pr) {
+    return (
+      allowPrAutoDetect &&
+      (currentStatus === SESSION_STATUS.WORKING || currentStatus === SESSION_STATUS.DONE)
+    );
+  }
+
+  switch (currentStatus) {
+    case SESSION_STATUS.WORKING:
+    case SESSION_STATUS.PR_OPEN:
+    case SESSION_STATUS.WAITING_CI:
+    case SESSION_STATUS.CI_FAILED:
+    case SESSION_STATUS.REVIEW_PENDING:
+    case SESSION_STATUS.CHANGES_REQUESTED:
+    case SESSION_STATUS.APPROVED:
+    case SESSION_STATUS.MERGEABLE:
+      return true;
+    default:
+      return false;
+  }
+}
+
+function isWaitingCiTimedOut(session: Session): boolean {
+  const waitingCiSinceMs = parseTimestampMs(session.metadata["waitingCiSince"]);
+  if (waitingCiSinceMs === null) {
+    return false;
+  }
+
+  return Date.now() - waitingCiSinceMs >= WAITING_CI_TIMEOUT_MS;
 }
 
 function shouldOverridePreservedPRStatus(status: SessionStatus): boolean {
@@ -359,6 +400,41 @@ function isSessionCleanupComplete(
       step.step !== "opencode",
   );
 }
+
+function buildStatusMetadataUpdates(
+  session: Session,
+  fromStatus: SessionStatus | undefined,
+  toStatus: SessionStatus,
+): Partial<Record<string, string>> {
+  const updates: Partial<Record<string, string>> = { status: toStatus };
+
+  if (toStatus === SESSION_STATUS.WAITING_CI) {
+    updates["waitingCiSince"] = session.metadata["waitingCiSince"] ?? new Date().toISOString();
+    updates["waitingCiTimedOutAt"] = "";
+    return updates;
+  }
+
+  if (fromStatus === SESSION_STATUS.WAITING_CI) {
+    updates["waitingCiSince"] = "";
+    updates["waitingCiTimedOutAt"] =
+      toStatus === SESSION_STATUS.DONE ? new Date().toISOString() : "";
+    return updates;
+  }
+
+  if (toStatus !== SESSION_STATUS.DONE && session.metadata["waitingCiTimedOutAt"]) {
+    updates["waitingCiTimedOutAt"] = "";
+  }
+
+  return updates;
+}
+
+const INACTIVE_SESSION_STATUSES: ReadonlySet<SessionStatus> = new Set([
+  SESSION_STATUS.KILLED,
+  SESSION_STATUS.DONE,
+  SESSION_STATUS.MERGED,
+  SESSION_STATUS.TERMINATED,
+  SESSION_STATUS.CLEANUP,
+]);
 
 /** Create a LifecycleManager instance. */
 export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleManager {
@@ -567,6 +643,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     currentStatus: SessionStatus,
     pollStats?: LifecyclePollStats,
   ): Promise<SessionStatus> {
+    if (
+      currentStatus === SESSION_STATUS.DONE &&
+      typeof session.metadata["waitingCiTimedOutAt"] === "string"
+    ) {
+      return SESSION_STATUS.DONE;
+    }
+
     const project = config.projects[session.projectId];
     if (!project) return currentStatus;
 
@@ -574,10 +657,14 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const agent = registry.get<Agent>("agent", agentName);
     const scm = project.scm ? registry.get<SCM>("scm", project.scm.plugin) : null;
     const scmPlugin = project.scm?.plugin ?? "unknown";
+    const allowPrAutoDetect =
+      scm !== null && Boolean(session.branch) && session.metadata["prAutoDetect"] !== "off";
 
     // Track activity state across steps so stuck detection can run after PR checks
     let detectedIdleTimestamp: Date | null = null;
     let preserveCurrentStatus = false;
+    let agentExitedWithOpenPR = false;
+    let retryExitedSessionAfterPrLookupError = false;
 
     // 1. Check if runtime is alive
     if (session.runtimeHandle) {
@@ -594,7 +681,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           });
           return true;
         });
-        if (!alive) return "killed";
+        if (!alive) {
+          if (shouldKeepPollingExitedPRSession(session, currentStatus, allowPrAutoDetect)) {
+            agentExitedWithOpenPR = true;
+          } else {
+            return "killed";
+          }
+        }
       }
     }
 
@@ -605,7 +698,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         const activityState = await agent.getActivityState(session, config.readyThresholdMs);
         if (activityState) {
           if (activityState.state === "waiting_input") return "needs_input";
-          if (activityState.state === "exited") return "killed";
+          if (activityState.state === "exited") {
+            if (shouldKeepPollingExitedPRSession(session, currentStatus, allowPrAutoDetect)) {
+              agentExitedWithOpenPR = true;
+            } else {
+              return "killed";
+            }
+          }
 
           // Stuck detection: if agent is idle/blocked beyond the configured threshold,
           // transition to "stuck" so the agent-stuck reaction can fire.
@@ -638,7 +737,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             if (activity === "waiting_input") return "needs_input";
 
             const processAlive = await agent.isProcessRunning(session.runtimeHandle);
-            if (!processAlive) return "killed";
+            if (!processAlive) {
+              if (shouldKeepPollingExitedPRSession(session, currentStatus, allowPrAutoDetect)) {
+                agentExitedWithOpenPR = true;
+              } else {
+                return "killed";
+              }
+            }
           }
         }
       } catch (error) {
@@ -689,6 +794,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           branch: session.branch,
           error,
         });
+        if (agentExitedWithOpenPR) {
+          retryExitedSessionAfterPrLookupError = true;
+        }
         // SCM detection failed — will retry next poll
       }
     }
@@ -713,6 +821,20 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           lastPrStatusPollAt: new Date().toISOString(),
           lastPrCiStatus: openPREvaluation.ciStatus,
         });
+
+        if (
+          agentExitedWithOpenPR &&
+          isWaitingForCiVerdict(openPREvaluation.ciStatus)
+        ) {
+          if (
+            currentStatus === SESSION_STATUS.WAITING_CI &&
+            isWaitingCiTimedOut(session)
+          ) {
+            return SESSION_STATUS.DONE;
+          }
+
+          return SESSION_STATUS.WAITING_CI;
+        }
 
         if (shouldOverridePreservedPRStatus(openPREvaluation.status)) {
           return openPREvaluation.status;
@@ -754,6 +876,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           return currentStatus;
         }
       }
+    }
+
+    if (agentExitedWithOpenPR && !session.pr) {
+      return retryExitedSessionAfterPrLookupError ? currentStatus : SESSION_STATUS.KILLED;
     }
 
     if (preserveCurrentStatus) {
@@ -1314,6 +1440,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         lastAutomatedReviewDispatchAt: "",
         lastPrStatusPollAt: "",
         lastPrCiStatus: "",
+        waitingCiSince: "",
+        waitingCiTimedOutAt: "",
       });
       return;
     }
@@ -1565,7 +1693,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
       // State transition detected
       states.set(session.id, newStatus);
-      updateSessionMetadata(session, { status: newStatus });
+      updateSessionMetadata(session, buildStatusMetadataUpdates(session, oldStatus, newStatus));
 
       // Reset allCompleteEmitted when any session becomes active again
       if (newStatus !== "merged" && newStatus !== "killed") {
@@ -1605,6 +1733,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
                 reactionResult.resultingStatus &&
                 reactionResult.resultingStatus !== newStatus
               ) {
+                const reactionFromStatus = newStatus;
                 const finalStatus = reactionResult.resultingStatus;
                 const finalEventType = statusToEventType(newStatus, finalStatus);
                 const finalReactionKey = finalEventType ? eventToReactionKey(finalEventType) : null;
@@ -1626,7 +1755,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
                 newStatus = finalStatus;
                 states.set(session.id, finalStatus);
-                updateSessionMetadata(session, { status: finalStatus });
+                updateSessionMetadata(
+                  session,
+                  buildStatusMetadataUpdates(session, reactionFromStatus, finalStatus),
+                );
               }
 
               // Reaction is handling this event — suppress immediate human notification.
@@ -1651,6 +1783,16 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           });
           await notifyHuman(event, priority, pollStats);
         }
+      }
+
+      if (oldStatus === SESSION_STATUS.WAITING_CI && newStatus === SESSION_STATUS.DONE) {
+        const event = createEvent("session.completed", {
+          sessionId: session.id,
+          projectId: session.projectId,
+          message: `${session.id}: CI did not report within 30 minutes; marking session done`,
+          data: { oldStatus, newStatus, reason: "waiting_ci_timeout" },
+        });
+        await notifyHuman(event, "warning", pollStats);
       }
     } else {
       // No transition but track current state
@@ -1693,12 +1835,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       // (e.g., list() detected a dead runtime and marked it "killed" — we need to
       // process that transition even though the new status is terminal)
       const sessionsToCheck = sessions.filter((s) => {
-        if (s.status !== "merged" && s.status !== "killed") return true;
+        if (!INACTIVE_SESSION_STATUSES.has(s.status)) return true;
         const tracked = states.get(s.id);
         return tracked !== undefined && tracked !== s.status;
       });
 
-      const activeSessions = sessions.filter((s) => s.status !== "merged" && s.status !== "killed");
+      const activeSessions = sessions.filter((s) => !INACTIVE_SESSION_STATUSES.has(s.status));
       pollStats.totalSessions = sessions.length;
       pollStats.checkedSessions = sessionsToCheck.length;
       pollStats.activeSessions = activeSessions.length;

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -114,6 +114,8 @@ export function readMetadata(dataDir: string, sessionId: SessionId): SessionMeta
     createdAt: raw["createdAt"],
     runtimeHandle: raw["runtimeHandle"],
     restoredAt: raw["restoredAt"],
+    waitingCiSince: raw["waitingCiSince"],
+    waitingCiTimedOutAt: raw["waitingCiTimedOutAt"],
     role: raw["role"],
     dashboardPort: raw["dashboardPort"] ? Number(raw["dashboardPort"]) : undefined,
     terminalWsPort: raw["terminalWsPort"] ? Number(raw["terminalWsPort"]) : undefined,
@@ -163,6 +165,9 @@ export function writeMetadata(
   if (metadata.createdAt) data["createdAt"] = metadata.createdAt;
   if (metadata.runtimeHandle) data["runtimeHandle"] = metadata.runtimeHandle;
   if (metadata.restoredAt) data["restoredAt"] = metadata.restoredAt;
+  if (metadata.waitingCiSince) data["waitingCiSince"] = metadata.waitingCiSince;
+  if (metadata.waitingCiTimedOutAt)
+    data["waitingCiTimedOutAt"] = metadata.waitingCiTimedOutAt;
   if (metadata.role) data["role"] = metadata.role;
   if (metadata.dashboardPort !== undefined) data["dashboardPort"] = String(metadata.dashboardPort);
   if (metadata.terminalWsPort !== undefined)

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -502,6 +502,7 @@ const VALID_STATUSES: ReadonlySet<string> = new Set([
   "spawning",
   "working",
   "pr_open",
+  "waiting_ci",
   "ci_failed",
   "review_pending",
   "changes_requested",
@@ -519,6 +520,7 @@ const VALID_STATUSES: ReadonlySet<string> = new Set([
 
 const PR_TRACKING_STATUSES: ReadonlySet<string> = new Set([
   "pr_open",
+  "waiting_ci",
   "ci_failed",
   "review_pending",
   "changes_requested",
@@ -881,7 +883,15 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
    * Enrich session with live runtime state (alive/exited) and activity detection.
    * Mutates the session object in place.
    */
-  const TERMINAL_SESSION_STATUSES = new Set(["killed", "done", "merged", "terminated", "cleanup"]);
+  const TERMINAL_SESSION_STATUSES = new Set([
+    "killed",
+    "done",
+    "merged",
+    "terminated",
+    "cleanup",
+    // waiting_ci intentionally keeps PR polling alive after the agent exits.
+    "waiting_ci",
+  ]);
 
   async function enrichSessionWithRuntimeState(
     session: Session,
@@ -902,7 +912,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       try {
         const alive = await plugins.runtime.isAlive(session.runtimeHandle);
         if (!alive) {
-          session.status = "killed";
+          // Preserve the persisted lifecycle status so the lifecycle manager can
+          // decide whether an exited session should be restored, marked killed,
+          // or kept alive for PR/CI tracking.
           session.activity = "exited";
           return;
         }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -27,6 +27,7 @@ export type SessionStatus =
   | "spawning"
   | "working"
   | "pr_open"
+  | "waiting_ci"
   | "ci_failed"
   | "review_pending"
   | "changes_requested"
@@ -75,6 +76,7 @@ export const SESSION_STATUS = {
   SPAWNING: "spawning" as const,
   WORKING: "working" as const,
   PR_OPEN: "pr_open" as const,
+  WAITING_CI: "waiting_ci" as const,
   CI_FAILED: "ci_failed" as const,
   REVIEW_PENDING: "review_pending" as const,
   CHANGES_REQUESTED: "changes_requested" as const,
@@ -1102,6 +1104,8 @@ export interface SessionMetadata {
   createdAt?: string;
   runtimeHandle?: string;
   restoredAt?: string;
+  waitingCiSince?: string;
+  waitingCiTimedOutAt?: string;
   role?: string; // "orchestrator" for orchestrator sessions
   dashboardPort?: number;
   terminalWsPort?: number;

--- a/packages/mobile/src/types/index.ts
+++ b/packages/mobile/src/types/index.ts
@@ -7,6 +7,7 @@ export type SessionStatus =
   | "spawning"
   | "working"
   | "pr_open"
+  | "waiting_ci"
   | "ci_failed"
   | "review_pending"
   | "changes_requested"
@@ -177,7 +178,7 @@ export function getAttentionLevel(session: DashboardSession): AttentionLevel {
   ) {
     return "respond";
   }
-  if (session.activity === "exited") {
+  if (session.activity === "exited" && session.status !== "waiting_ci") {
     return "respond";
   }
 
@@ -193,7 +194,7 @@ export function getAttentionLevel(session: DashboardSession): AttentionLevel {
   }
 
   // Pending: waiting on external
-  if (session.status === "review_pending") {
+  if (session.status === "review_pending" || session.status === "waiting_ci") {
     return "pending";
   }
   if (session.pr && !isPRRateLimited(session.pr)) {

--- a/packages/web/src/lib/__tests__/types.test.ts
+++ b/packages/web/src/lib/__tests__/types.test.ts
@@ -322,6 +322,11 @@ describe("getAttentionLevel", () => {
       expect(getAttentionLevel(session)).toBe("pending");
     });
 
+    it("should return 'pending' for waiting_ci even after the agent exits", () => {
+      const session = createSession({ status: "waiting_ci", activity: "exited" });
+      expect(getAttentionLevel(session)).toBe("pending");
+    });
+
     it("should return 'pending' when PR has unresolved threads", () => {
       const session = createSession({
         status: "pr_open",

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -236,7 +236,10 @@ export function getAttentionLevel(session: DashboardSession): AttentionLevel {
     return "respond";
   }
   // Exited agent with non-terminal status = crashed, needs human attention
-  if (session.activity === ACTIVITY_STATE.EXITED) {
+  if (
+    session.activity === ACTIVITY_STATE.EXITED &&
+    session.status !== SESSION_STATUS.WAITING_CI
+  ) {
     return "respond";
   }
 
@@ -252,7 +255,10 @@ export function getAttentionLevel(session: DashboardSession): AttentionLevel {
   }
 
   // ── Pending: waiting on external (reviewer, CI) ───────────────────
-  if (session.status === "review_pending") {
+  if (
+    session.status === SESSION_STATUS.REVIEW_PENDING ||
+    session.status === SESSION_STATUS.WAITING_CI
+  ) {
     return "pending";
   }
   if (session.pr && !isPRRateLimited(session.pr)) {


### PR DESCRIPTION
## Summary
- add a waiting_ci lifecycle state so PR-owning sessions stay pollable after the agent exits
- wake exited sessions back up when CI later fails, and time out stalled CI waits after 30 minutes with a warning
- update session manager, dashboard/mobile status handling, and tests for the new flow

## Testing
- pnpm run build
- pnpm run typecheck
- pnpm test
- pnpm run lint
- pnpm --filter @composio/ao-web test -- src/lib/__tests__/types.test.ts

Closes #413