### PR TITLE
feat: emit session.completed for finished sessions

### DIFF
--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -31,6 +31,8 @@ export function statusColor(status: string): string {
   switch (status) {
     case "working":
       return chalk.green(status);
+    case "completed":
+      return chalk.cyan(status);
     case "idle":
       return chalk.yellow(status);
     case "pr_open":

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -62,7 +62,8 @@ Polls sessions, detects state changes, triggers reactions:
 **State machine:**
 
 ```
-spawning → working → pr_open → waiting_ci → ci_failed/review_pending/approved → mergeable → merged
+spawning → working → completed
+                 └→ pr_open → waiting_ci → ci_failed/review_pending/approved → mergeable → merged
 ```
 
 **Reactions:**

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -598,6 +598,126 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("killed");
   });
 
+  it("detects completed when agent reports ready without a PR", async () => {
+    vi.useFakeTimers();
+    const transitionTime = new Date("2026-03-10T12:00:00.000Z");
+    vi.setSystemTime(transitionTime);
+    config.notificationRouting.info = ["desktop"];
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    vi.mocked(mockAgent.getActivityState).mockResolvedValue({
+      state: "ready",
+      timestamp: transitionTime,
+    });
+
+    const session = makeSession({ status: "working", pr: null });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("completed");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("completed");
+    expect(mockNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "session.completed",
+        priority: "info",
+        idempotencyKey: computeEventIdempotencyKey(
+          "app-1",
+          "session.completed",
+          "working",
+          "completed",
+          transitionTime,
+        ),
+      }),
+    );
+  });
+
+  it("emits completed before escalating a long-idle session to stuck", async () => {
+    config.notificationRouting.info = ["desktop"];
+    config.notificationRouting.urgent = ["desktop"];
+    config.reactions["agent-stuck"] = {
+      auto: true,
+      action: "notify",
+      priority: "urgent",
+      threshold: "1m",
+    };
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const idleTimestamp = new Date(Date.now() - 120_000);
+    vi.mocked(mockAgent.getActivityState).mockResolvedValue({
+      state: "idle",
+      timestamp: idleTimestamp,
+    });
+
+    const session = makeSession({ status: "working", pr: null });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("completed");
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("stuck");
+    expect(vi.mocked(mockNotifier.notify).mock.calls.map(([event]) => event.type)).toEqual([
+      "session.completed",
+      "reaction.triggered",
+    ]);
+  });
+
   it("stays working when agent is idle but process is still running (fallback path)", async () => {
     vi.mocked(mockAgent.getActivityState).mockResolvedValue(null);
     vi.mocked(mockAgent.detectActivity).mockReturnValue("idle");
@@ -622,6 +742,54 @@ describe("check (single session)", () => {
     await lm.check("app-1");
 
     expect(lm.getStates().get("app-1")).toBe("working");
+  });
+
+  it("returns completed sessions to working when the agent becomes active again", async () => {
+    config.notificationRouting.info = ["desktop"];
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    vi.mocked(mockAgent.getActivityState).mockResolvedValue({ state: "active" });
+
+    const session = makeSession({ status: "completed", pr: null });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "completed",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("working");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("working");
+    expect(mockNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "session.working",
+        priority: "info",
+      }),
+    );
   });
 
   it("detects needs_input from agent", async () => {
@@ -1925,15 +2093,10 @@ describe("reactions", () => {
     expect(getLifecycleLogs()).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          event: "notification.deduplicated",
+          event: "notification.skipped",
           eventType: "session.completed",
-          idempotencyKey: computeEventIdempotencyKey(
-            "app-1",
-            "merge.ready",
-            "pr_open",
-            "mergeable",
-            transitionTime,
-          ),
+          priority: "info",
+          reason: "no_notifiers_configured",
         }),
       ]),
     );
@@ -2064,8 +2227,10 @@ describe("reactions", () => {
           fallbackApplied: true,
         }),
         expect.objectContaining({
-          event: "notification.deduplicated",
+          event: "notification.skipped",
           eventType: "session.completed",
+          priority: "info",
+          reason: "no_notifiers_configured",
         }),
       ]),
     );

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -66,7 +66,7 @@ function inferPriority(type: EventType): EventPriority {
   if (type.includes("stuck") || type.includes("needs_input") || type.includes("errored")) {
     return "urgent";
   }
-  if (type.startsWith("summary.")) {
+  if (type === "session.completed" || type.startsWith("summary.")) {
     return "info";
   }
   if (
@@ -199,6 +199,8 @@ function statusToEventType(_from: SessionStatus | undefined, to: SessionStatus):
   switch (to) {
     case "working":
       return "session.working";
+    case "completed":
+      return "session.completed";
     case "pr_open":
       return "pr.created";
     case "ci_failed":
@@ -1145,6 +1147,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     // Track activity state across steps so stuck detection can run after PR checks
     let detectedIdleTimestamp: Date | null = null;
+    let detectedCompletionState: "ready" | "idle" | null = null;
     let preserveCurrentStatus = false;
     let agentExitedWithOpenPR = false;
     let retryExitedSessionAfterPrLookupError = false;
@@ -1189,25 +1192,20 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             }
           }
 
-          // Stuck detection: if agent is idle/blocked beyond the configured threshold,
-          // transition to "stuck" so the agent-stuck reaction can fire.
-          // BUT: if the session already has a PR, fall through to step 4 so
-          // merge-readiness is checked first. Without this, stuck detection
-          // short-circuits before the PR state checks and "mergeable" is
-          // never reached — causing the pipeline to stall.
+          if (activityState.state === "ready" || activityState.state === "idle") {
+            detectedCompletionState = activityState.state;
+          }
+
+          // Stuck/completion detection runs after PR auto-detection so sessions
+          // with branch-backed PRs can still be promoted into PR states first.
           if (
             (activityState.state === "idle" || activityState.state === "blocked") &&
             activityState.timestamp
           ) {
-            if (isIdleBeyondThreshold(session, activityState.timestamp) && !session.pr) {
-              return "stuck";
-            }
-            // Store idle timestamp for post-PR-check stuck detection (step 4b)
             detectedIdleTimestamp = activityState.timestamp;
           }
 
-          // active/ready/idle (below threshold)/blocked (below threshold) —
-          // proceed to PR checks below
+          // active/ready/idle/blocked — proceed to PR checks below
         } else {
           // getActivityState returned null — fall back to terminal output parsing
           const runtime = registry.get<Runtime>(
@@ -1363,15 +1361,31 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       return currentStatus;
     }
 
-    // 5. Post-all stuck detection: if we detected idle in step 2 but had no PR,
-    // still check stuck threshold. This handles agents that finish without creating a PR.
+    // 5. Agents can finish a turn without exiting. When they become ready/idle and
+    // no PR state takes precedence, surface that as a non-terminal completed state.
+    if (!session.pr && detectedCompletionState) {
+      if (
+        currentStatus === SESSION_STATUS.COMPLETED &&
+        detectedIdleTimestamp &&
+        isIdleBeyondThreshold(session, detectedIdleTimestamp)
+      ) {
+        return SESSION_STATUS.STUCK;
+      }
+
+      return SESSION_STATUS.COMPLETED;
+    }
+
+    // 6. Post-all stuck detection: if we detected idle in step 2 but had no PR,
+    // still check stuck threshold. This handles agents that stay inactive after
+    // completion detection was already emitted.
     if (detectedIdleTimestamp && isIdleBeyondThreshold(session, detectedIdleTimestamp)) {
       return "stuck";
     }
 
-    // 6. Default: if agent is active, it's working
+    // 7. Default: if agent is active again, it's working
     if (
       currentStatus === SESSION_STATUS.SPAWNING ||
+      currentStatus === SESSION_STATUS.COMPLETED ||
       currentStatus === SESSION_STATUS.STUCK ||
       currentStatus === SESSION_STATUS.NEEDS_INPUT
     ) {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -501,6 +501,7 @@ function safeJsonParse<T>(str: string): T | null {
 const VALID_STATUSES: ReadonlySet<string> = new Set([
   "spawning",
   "working",
+  "completed",
   "pr_open",
   "waiting_ci",
   "ci_failed",
@@ -2185,8 +2186,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       ]);
 
       // Prefer the live runtime/process check over stale metadata status.
-      // Sessions can sit idle at their prompt with statuses like "done" or
-      // "stuck" while still accepting new input. If the runtime is alive and
+      // Sessions can sit idle at their prompt with statuses like "completed",
+      // "done", or "stuck" while still accepting new input. If the runtime is alive and
       // the agent process is still present, we should deliver directly instead
       // of forcing a restore based only on the recorded status.
       if (runtimeAlive && processRunning) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,6 +26,7 @@ export type SessionId = string;
 export type SessionStatus =
   | "spawning"
   | "working"
+  | "completed"
   | "pr_open"
   | "waiting_ci"
   | "ci_failed"
@@ -75,6 +76,7 @@ export const DEFAULT_READY_THRESHOLD_MS = 300_000; // 5 minutes
 export const SESSION_STATUS = {
   SPAWNING: "spawning" as const,
   WORKING: "working" as const,
+  COMPLETED: "completed" as const,
   PR_OPEN: "pr_open" as const,
   WAITING_CI: "waiting_ci" as const,
   CI_FAILED: "ci_failed" as const,

--- a/packages/mobile/src/types/index.ts
+++ b/packages/mobile/src/types/index.ts
@@ -6,6 +6,7 @@
 export type SessionStatus =
   | "spawning"
   | "working"
+  | "completed"
   | "pr_open"
   | "waiting_ci"
   | "ci_failed"
@@ -145,6 +146,7 @@ export function isPRRateLimited(pr: DashboardPR): boolean {
 export function getAttentionLevel(session: DashboardSession): AttentionLevel {
   // Done: terminal states
   if (
+    session.status === "completed" ||
     session.status === "merged" ||
     session.status === "killed" ||
     session.status === "cleanup" ||

--- a/packages/web/src/lib/__tests__/types.test.ts
+++ b/packages/web/src/lib/__tests__/types.test.ts
@@ -62,6 +62,11 @@ describe("getAttentionLevel", () => {
       expect(getAttentionLevel(session)).toBe("done");
     });
 
+    it("should return 'done' for completed status", () => {
+      const session = createSession({ status: "completed" });
+      expect(getAttentionLevel(session)).toBe("done");
+    });
+
     it("should return 'done' for terminated status", () => {
       const session = createSession({ status: "terminated" });
       expect(getAttentionLevel(session)).toBe("done");

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -50,7 +50,7 @@ export { TERMINAL_STATUSES, TERMINAL_ACTIVITIES, NON_RESTORABLE_STATUSES };
  * 3. review  — CI failed, changes requested, conflicts. Needs investigation.
  * 4. pending — Waiting on external (reviewer, CI). Nothing to do right now.
  * 5. working — Agents doing their thing. Don't interrupt.
- * 6. done    — Merged or terminated. Archive.
+ * 6. done    — Completed, merged, or terminated. Archive.
  */
 export type AttentionLevel = "merge" | "respond" | "review" | "pending" | "working" | "done";
 
@@ -195,6 +195,7 @@ export function isPRMergeReady(pr: DashboardPR): boolean {
 export function getAttentionLevel(session: DashboardSession): AttentionLevel {
   // ── Done: terminal states ─────────────────────────────────────────
   if (
+    session.status === "completed" ||
     session.status === "merged" ||
     session.status === "killed" ||
     session.status === "cleanup" ||


### PR DESCRIPTION
## Summary
- add a non-terminal completed session status for agents that finish a turn but remain alive
- emit session.completed when activity becomes ready or idle without a PR state taking precedence, and restore working when the agent resumes
- update shared dashboard and mobile status handling plus lifecycle tests for completion and later stuck escalation

## Verification
- pnpm run typecheck
- pnpm test
- pnpm run lint

Closes #377