### PR TITLE
docs: rebrand documentation to syntese

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -2,7 +2,7 @@
 
 ## Project Context
 
-Agent Orchestrator is a TypeScript monorepo for managing parallel AI coding agents. It uses pnpm workspaces with packages under `packages/`.
+Syntese is a TypeScript monorepo for managing parallel AI coding agents. It uses pnpm workspaces with packages under `packages/`.
 
 ## Tech Stack
 

--- a/.github/workflows/fork-ci.yml
+++ b/.github/workflows/fork-ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   lint:
-    if: github.repository == 'sigvardt/agent-orchestrator'
+    if: github.repository == 'sigvardt/syntese'
     name: Lint
     runs-on: ubuntu-latest
     steps:
@@ -26,7 +26,7 @@ jobs:
       - run: pnpm run lint
 
   typecheck:
-    if: github.repository == 'sigvardt/agent-orchestrator'
+    if: github.repository == 'sigvardt/syntese'
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
@@ -45,7 +45,7 @@ jobs:
         run: pnpm --filter @composio/ao-web build
 
   test:
-    if: github.repository == 'sigvardt/agent-orchestrator'
+    if: github.repository == 'sigvardt/syntese'
     name: Test
     runs-on: ubuntu-latest
     steps:
@@ -62,7 +62,7 @@ jobs:
         run: pnpm test
 
   test-web:
-    if: github.repository == 'sigvardt/agent-orchestrator'
+    if: github.repository == 'sigvardt/syntese'
     name: Test (Web Unit)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   release:
-    if: github.repository == 'sigvardt/agent-orchestrator'
+    if: github.repository == 'sigvardt/syntese'
     name: Release
     runs-on: ubuntu-latest
     permissions:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 ## Core Principles
 
 1. **Convention over configuration** - Auto-derive everything possible
-2. **Single source of truth** - Config file in repo, runtime data in `~/.agent-orchestrator/`
+2. **Single source of truth** - Config file in repo, runtime data in `~/.syntese/`
 3. **Zero path configuration** - All paths determined automatically
 4. **Global uniqueness** - Hash-based namespacing prevents collisions
 
@@ -13,13 +13,13 @@
 
 ```
 Repo (versioned):
-~/any/path/to/agent-orchestrator/
-  agent-orchestrator.yaml              ← Config file (only this matters)
+~/any/path/to/syntese/
+  syntese.yaml              ← Config file (only this matters)
   packages/
   ...
 
 Runtime Data (not versioned):
-~/.agent-orchestrator/                 ← Single parent directory
+~/.syntese/                 ← Single parent directory
   a3b4c5d6e7f8-integrator/             ← {hash}-{projectId}
     sessions/
       int-1                            ← Session metadata files (no hash prefix)
@@ -42,7 +42,7 @@ Runtime Data (not versioned):
 **Hash Derivation (from config location):**
 
 ```typescript
-const configDir = path.dirname(configPath); // /Users/alice/code/agent-orchestrator
+const configDir = path.dirname(configPath); // /Users/alice/code/syntese
 const hash = sha256(configDir).slice(0, 12); // a3b4c5d6e7f8
 
 // Each project managed by this config gets a directory
@@ -51,7 +51,7 @@ const projectId = path.basename(projectPath); // integrator, backend, etc.
 const instanceId = `${hash}-${projectId}`; // a3b4c5d6e7f8-integrator
 
 // Not configurable!
-const projectBaseDir = `~/.agent-orchestrator/${instanceId}`;
+const projectBaseDir = `~/.syntese/${instanceId}`;
 const sessionsDir = `${projectBaseDir}/sessions`;
 const worktreesDir = `${projectBaseDir}/worktrees`;
 ```
@@ -63,7 +63,7 @@ const worktreesDir = `${projectBaseDir}/worktrees`;
 ## 2. Config File (Minimal)
 
 ```yaml
-# agent-orchestrator.yaml
+# syntese.yaml
 
 projects:
   - path: ~/repos/integrator # Required: where is the repo?
@@ -93,7 +93,7 @@ projects:
 {sessionPrefix}-{num}
 
 int-1, int-2    (integrator)
-ao-1, ao-2      (agent-orchestrator)
+syn-1, syn-2    (syntese)
 ss-1, ss-2      (safe-split)
 ```
 
@@ -119,7 +119,7 @@ function generateSessionPrefix(projectId: string): string {
     return uppercase.join("").toLowerCase();
   }
 
-  // kebab-case: agent-orchestrator → ao
+  // kebab-case: syntese-platform → sp
   if (projectId.includes("-") || projectId.includes("_")) {
     const sep = projectId.includes("-") ? "-" : "_";
     return projectId
@@ -141,7 +141,7 @@ function generateSessionPrefix(projectId: string): string {
 ### File Structure (One Directory Per Project)
 
 ```
-~/.agent-orchestrator/a3b4c5d6e7f8-integrator/
+~/.syntese/a3b4c5d6e7f8-integrator/
   sessions/
     int-1      ← Metadata file (user-facing session name)
     int-2
@@ -160,7 +160,7 @@ issue=INT-100
 branch=feat/INT-100
 status=working
 tmuxName=a3b4c5d6e7f8-int-1
-worktree=/Users/alice/.agent-orchestrator/a3b4c5d6e7f8-integrator/worktrees/int-1
+worktree=/Users/alice/.syntese/a3b4c5d6e7f8-integrator/worktrees/int-1
 createdAt=2026-02-17T10:30:00Z
 pr=https://github.com/ComposioHQ/integrator/pull/123
 ```
@@ -206,7 +206,7 @@ ao info
 ### Same Config → Same Hash
 
 ```yaml
-# ~/code/my-orchestrator/agent-orchestrator.yaml
+# ~/code/my-orchestrator/syntese.yaml
 projects:
   - path: ~/repos/integrator
   - path: ~/repos/backend
@@ -215,7 +215,7 @@ projects:
 Results in:
 
 ```
-~/.agent-orchestrator/
+~/.syntese/
   a3b4c5d6e7f8-integrator/        ← Same hash (same config)
   a3b4c5d6e7f8-backend/           ← Same hash (same config)
 ```
@@ -231,7 +231,7 @@ Results in:
 Results in:
 
 ```
-~/.agent-orchestrator/
+~/.syntese/
   a3b4c5d6e7f8-integrator/        ← From ~/code/orchestrator
   f1e2d3c4b5a6-integrator/        ← From ~/code/orchestrator-v2 (different checkout!)
   9876abcd5432-safesplit/         ← From ~/splitly-orchestrator
@@ -249,7 +249,7 @@ f1e2d3c4b5a6-int-1    (v2 checkout)
 ## 7. Complete Example
 
 ```yaml
-# ~/code/my-orchestrator/agent-orchestrator.yaml
+# ~/code/my-orchestrator/syntese.yaml
 projects:
   - path: ~/repos/integrator
     repo: ComposioHQ/integrator
@@ -269,7 +269,7 @@ Config location:
   → Hash: a3b4c5d6e7f8
 
 Runtime data:
-  ~/.agent-orchestrator/
+  ~/.syntese/
     a3b4c5d6e7f8-integrator/      ← Project 1
       sessions/
         int-1

--- a/DESIGN-OPENCLAW-PLUGIN.md
+++ b/DESIGN-OPENCLAW-PLUGIN.md
@@ -51,7 +51,7 @@ OpenClaw already supports:
 ## Request payload (Phase 0)
 ```json
 {
-  "message": "[AO Escalation] ao-5 failed CI 5 times on feat/ci-auto-injection. Last error: type mismatch in codex plugin. PR: github.com/ComposioHQ/agent-orchestrator/pull/123. Actions available: retry, skip, kill. Context: {\"sessionId\":\"ao-5\",\"projectId\":\"ao\",\"reason\":\"ci_failed\",\"attempts\":5}",
+  "message": "[AO Escalation] ao-5 failed CI 5 times on feat/ci-auto-injection. Last error: type mismatch in codex plugin. PR: github.com/sigvardt/syntese/pull/123. Actions available: retry, skip, kill. Context: {\"sessionId\":\"ao-5\",\"projectId\":\"ao\",\"reason\":\"ci_failed\",\"attempts\":5}",
   "name": "AO",
   "sessionKey": "hook:ao:ao-5",
   "wakeMode": "now",
@@ -210,7 +210,7 @@ When implementing Phase 1/2 plugin, model structure after:
 - Teams/Matrix channel plugins for robust bidirectional routing patterns.
 - Memory plugins for slot/service/tool separation patterns.
 
-## `agent-orchestrator.yaml` (Phase 0)
+## `syntese.yaml` (Phase 0)
 
 ```yaml
 defaults:

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -1,6 +1,6 @@
 # Fork Changelog
 
-All notable changes to `sigvardt/agent-orchestrator` are documented here.
+All notable changes to `sigvardt/syntese` are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and fork releases use tags like `v0.1.0-sigvardt.1`.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-<h1 align="center">Agent Orchestrator — The Orchestration Layer for Parallel AI Agents</h1>
+<h1 align="center">Syntese — The Orchestration Layer for Parallel AI Agents</h1>
 
 <p align="center">
-<a href="https://platform.composio.dev/?utm_source=Github&utm_medium=Banner&utm_content=AgentOrchestrator">
-  <img width="800" alt="Agent Orchestrator banner" src="docs/assets/agent_orchestrator_banner.png">
+<a href="https://platform.composio.dev/?utm_source=Github&utm_medium=Banner&utm_content=Syntese">
+  <img width="800" alt="Syntese banner" src="docs/assets/agent_orchestrator_banner.png">
 </a>
 </p>
 
@@ -10,17 +10,19 @@
 
 Spawn parallel AI coding agents, each in its own git worktree. Agents autonomously fix CI failures, address review comments, and open PRs — you supervise from one dashboard.
 
-[![GitHub stars](https://img.shields.io/github/stars/ComposioHQ/agent-orchestrator?style=flat-square)](https://github.com/ComposioHQ/agent-orchestrator/stargazers)
+[![GitHub stars](https://img.shields.io/github/stars/sigvardt/syntese?style=flat-square)](https://github.com/sigvardt/syntese/stargazers)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
-[![PRs merged](https://img.shields.io/badge/PRs_merged-61-brightgreen?style=flat-square)](https://github.com/ComposioHQ/agent-orchestrator/pulls?q=is%3Amerged)
-[![Tests](https://img.shields.io/badge/test_cases-3%2C288-blue?style=flat-square)](https://github.com/ComposioHQ/agent-orchestrator/releases/tag/metrics-v1)
+[![PRs merged](https://img.shields.io/badge/PRs_merged-61-brightgreen?style=flat-square)](https://github.com/sigvardt/syntese/pulls?q=is%3Amerged)
+[![Tests](https://img.shields.io/badge/test_cases-3%2C288-blue?style=flat-square)](https://github.com/sigvardt/syntese/releases/tag/metrics-v1)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Community-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/P9BytfBj)
 
 </div>
 
 ---
 
-Agent Orchestrator manages fleets of AI coding agents working in parallel on your codebase. Each agent gets its own git worktree, its own branch, and its own PR. When CI fails, the agent fixes it. When reviewers leave comments, the agent addresses them. You only get pulled in when human judgment is needed.
+Syntese manages fleets of AI coding agents working in parallel on your codebase. Each agent gets its own git worktree, its own branch, and its own PR. When CI fails, the agent fixes it. When reviewers leave comments, the agent addresses them. You only get pulled in when human judgment is needed.
+
+`ao` remains the backward-compatible CLI alias, so the commands below continue to use `ao`.
 
 **Agent-agnostic** (Claude Code, Codex, Aider) · **Runtime-agnostic** (tmux, Docker) · **Tracker-agnostic** (GitHub, Linear)
 
@@ -29,7 +31,7 @@ Agent Orchestrator manages fleets of AI coding agents working in parallel on you
 ## See it in action
 
 <a href="https://x.com/agent_wrapper/status/2026329204405723180">
-  <img src="docs/assets/demo-video-tweet.png" alt="Agent Orchestrator demo — AI agents building their own orchestrator" width="560">
+  <img src="docs/assets/demo-video-tweet.png" alt="Syntese demo — AI agents building their own orchestrator" width="560">
 </a>
 <br><br>
 <a href="https://x.com/agent_wrapper/status/2026329204405723180"><img src="docs/assets/btn-watch-demo.png" alt="Watch the Demo on X" height="48"></a>
@@ -48,14 +50,14 @@ Agent Orchestrator manages fleets of AI coding agents working in parallel on you
 
 ```bash
 # Install
-git clone https://github.com/ComposioHQ/agent-orchestrator.git
-cd agent-orchestrator && bash scripts/setup.sh
+git clone https://github.com/sigvardt/syntese.git
+cd syntese && bash scripts/setup.sh
 
 # One command to clone, configure, and launch
 ao start https://github.com/your-org/your-repo
 ```
 
-Auto-detects language, package manager, SCM platform, and default branch. Generates `agent-orchestrator.yaml` and starts the dashboard + orchestrator.
+Auto-detects language, package manager, SCM platform, and default branch. Generates `syntese.yaml` and starts the dashboard + orchestrator.
 On supported hosts, `ao start` also brings up the supervised dashboard services automatically. Use `ao services status --strict` to confirm dashboard and websocket readiness.
 
 **Option B — From an existing local repo:**
@@ -113,7 +115,7 @@ All interfaces defined in [`packages/core/src/types.ts`](packages/core/src/types
 ## Configuration
 
 ```yaml
-# agent-orchestrator.yaml
+# syntese.yaml
 port: 3000
 
 defaults:
@@ -159,7 +161,7 @@ CI fails → agent gets the logs and fixes it. Reviewer requests changes → age
 
 If a project needs live verification beyond CI, `verification.postPush` runs a project-defined command after each new pushed `HEAD`. `block-merge` prevents auto-merge and the dashboard merge action until that verification passes.
 
-See [`agent-orchestrator.yaml.example`](agent-orchestrator.yaml.example) for the full reference.
+See [`syntese.yaml.example`](syntese.yaml.example) for the full reference.
 
 ## CLI
 
@@ -192,13 +194,13 @@ ao services install
 ao services status --strict
 ```
 
-## Why Agent Orchestrator?
+## Why Syntese?
 
 Running one AI agent in a terminal is easy. Running 30 across different issues, branches, and PRs is a coordination problem.
 
 **Without orchestration**, you manually: create branches, start agents, check if they're stuck, read CI failures, forward review comments, track which PRs are ready to merge, clean up when done.
 
-**With Agent Orchestrator**, you: `ao spawn` and walk away. The system handles isolation, feedback routing, and status tracking. You review PRs and make decisions — the rest is automated.
+**With Syntese**, you: `ao spawn` and walk away. The system handles isolation, feedback routing, and status tracking. You review PRs and make decisions — the rest is automated.
 
 ## Prerequisites
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,6 +1,8 @@
-# Agent Orchestrator Setup Guide
+# Syntese Setup Guide
 
-Comprehensive guide to installing, configuring, and troubleshooting Agent Orchestrator.
+Comprehensive guide to installing, configuring, and troubleshooting Syntese.
+
+`ao` remains the backward-compatible CLI alias, so the commands in this guide continue to use `ao`.
 
 ## Prerequisites
 
@@ -63,8 +65,8 @@ The package is not yet published to npm. Install by building from source:
 
 ```bash
 # Clone the repository
-git clone https://github.com/ComposioHQ/agent-orchestrator
-cd agent-orchestrator
+git clone https://github.com/sigvardt/syntese
+cd syntese
 
 # Install dependencies (requires pnpm)
 pnpm install
@@ -101,7 +103,7 @@ This single command will:
 
 1. **Clone** the repo (or reuse an existing clone)
 2. **Auto-detect** language, package manager, SCM platform, and default branch
-3. **Generate** `agent-orchestrator.yaml` with smart defaults
+3. **Generate** `syntese.yaml` with smart defaults
 4. **Start** supervised dashboard + terminal websocket services and the orchestrator agent
 
 Supports GitHub, GitLab, and Bitbucket URLs (HTTPS and SSH):
@@ -112,7 +114,7 @@ ao start https://gitlab.com/org/project
 ao start git@github.com:owner/repo.git
 ```
 
-If the repo already has an `agent-orchestrator.yaml`, it will be used as-is.
+If the repo already has a `syntese.yaml`, it will be used as-is.
 
 ### Supervised Runtime (Recommended)
 
@@ -148,7 +150,7 @@ ao init
 
 The wizard will prompt you for:
 
-1. **Data directory** - Where to store session metadata (default: `~/.agent-orchestrator`)
+1. **Data directory** - Where to store session metadata (default: `~/.syntese`)
 2. **Worktree directory** - Where to create isolated workspaces (default: `~/.worktrees`)
 3. **Dashboard port** - Web interface port (default: `3000`)
 4. **Runtime plugin** - Session runtime (default: `tmux`)
@@ -176,15 +178,15 @@ The wizard is smart and tries to help:
 If you prefer to write the config manually:
 
 ```bash
-cp agent-orchestrator.yaml.example agent-orchestrator.yaml
-nano agent-orchestrator.yaml
+cp syntese.yaml.example syntese.yaml
+nano syntese.yaml
 ```
 
 Or start from an example:
 
 ```bash
-cp examples/simple-github.yaml agent-orchestrator.yaml
-nano agent-orchestrator.yaml
+cp examples/simple-github.yaml syntese.yaml
+nano syntese.yaml
 ```
 
 ## Configuration Reference
@@ -194,7 +196,7 @@ nano agent-orchestrator.yaml
 The absolute minimum needed:
 
 ```yaml
-dataDir: ~/.agent-orchestrator
+dataDir: ~/.syntese
 worktreeDir: ~/.worktrees
 port: 3000
 
@@ -207,11 +209,11 @@ projects:
 
 ### Full Configuration Schema
 
-See [agent-orchestrator.yaml.example](./agent-orchestrator.yaml.example) for a fully commented example with all options.
+See [syntese.yaml.example](./syntese.yaml.example) for a fully commented example with all options.
 
 ### Plugin Slots
 
-Agent Orchestrator has 8 plugin slots. All are swappable:
+Syntese has 8 plugin slots. All are swappable:
 
 | Slot          | Purpose              | Default       | Alternatives                                    |
 | ------------- | -------------------- | ------------- | ----------------------------------------------- |
@@ -358,7 +360,7 @@ gh auth status
    - Click "Create new key" or use existing key
    - Team ID is visible in your Linear workspace URL or via API
 
-4. Configure in `agent-orchestrator.yaml`:
+4. Configure in `syntese.yaml`:
    ```yaml
    projects:
      my-app:
@@ -385,7 +387,7 @@ echo $LINEAR_API_KEY  # Should print your key
    source ~/.zshrc
    ```
 
-3. Configure in `agent-orchestrator.yaml`:
+3. Configure in `syntese.yaml`:
    ```yaml
    notifiers:
      slack:
@@ -399,7 +401,7 @@ echo $LINEAR_API_KEY  # Should print your key
 ```bash
 # Send test message
 curl -X POST -H 'Content-type: application/json' \
-  --data '{"text":"Agent Orchestrator test"}' \
+  --data '{"text":"Syntese test"}' \
   $SLACK_WEBHOOK_URL
 ```
 
@@ -415,7 +417,7 @@ See [CLAUDE.md](./CLAUDE.md) for plugin development guidelines.
 
 ## Troubleshooting
 
-### "No agent-orchestrator.yaml found"
+### "No syntese.yaml found"
 
 **Problem:** The orchestrator can't find your config file.
 
@@ -426,7 +428,7 @@ See [CLAUDE.md](./CLAUDE.md) for plugin development guidelines.
 ao init
 
 # Or copy an example
-cp examples/simple-github.yaml agent-orchestrator.yaml
+cp examples/simple-github.yaml syntese.yaml
 ```
 
 ### "tmux not found"
@@ -492,7 +494,7 @@ echo $LINEAR_API_KEY
 **Solution:**
 
 ```bash
-# Option 1: Change port in agent-orchestrator.yaml
+# Option 1: Change port in syntese.yaml
 port: 3001
 
 # Option 2: Find and kill the process using the port
@@ -572,7 +574,7 @@ gh auth login
 
 ### "YAML parse error"
 
-**Problem:** Syntax error in `agent-orchestrator.yaml`.
+**Problem:** Syntax error in `syntese.yaml`.
 
 **Solution:**
 
@@ -843,4 +845,4 @@ Useful for:
 
 ---
 
-**Need help?** Open an issue at: https://github.com/ComposioHQ/agent-orchestrator/issues
+**Need help?** Open an issue at: https://github.com/sigvardt/syntese/issues

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -80,10 +80,10 @@ npx node-gyp rebuild
 
 ### Config file not found
 
-**Symptom**: API returns 500 with "No agent-orchestrator.yaml found"
+**Symptom**: API returns 500 with "No syntese.yaml found"
 
 **Fix**: Ensure config exists in the directory where you run `ao start`, or symlink it:
 
 ```bash
-ln -s /path/to/agent-orchestrator.yaml packages/web/agent-orchestrator.yaml
+ln -s /path/to/syntese.yaml packages/web/syntese.yaml
 ```

--- a/artifacts/architecture-design.md
+++ b/artifacts/architecture-design.md
@@ -1,4 +1,4 @@
-# Architecture Design — Agent Orchestrator
+# Architecture Design — Syntese
 
 _Compiled: 2026-02-13_
 
@@ -34,7 +34,7 @@ Human only intervenes when notified. Everything else is handled.
 1. **Push, not pull**: Notifications are the primary interface. Dashboard is secondary drill-down.
 2. **Server-centric**: All agents report to a central server. The server coordinates everything.
 3. **Plugin everything**: 8 pluggable abstraction slots. Swap any component.
-4. **Works out of the box**: Default config (tmux + claude-code + worktree + github) requires zero setup beyond `npx agent-orchestrator init`.
+4. **Works out of the box**: Default config (tmux + claude-code + worktree + github) requires zero setup beyond `npx syntese init`.
 5. **Silence by default, loud when needed**: Auto-handle routine issues (CI failures, review comments). Only notify the human when their judgment or action is truly required.
 6. **Runtime agnostic**: tmux is just one way to run agents. Docker, K8s, cloud, SSH, child processes — all through the same interface.
 
@@ -457,7 +457,7 @@ notifications:
 ### Reactions (configurable auto-responses)
 
 ```yaml
-# agent-orchestrator.yaml
+# syntese.yaml
 reactions:
   ci-failed:
     auto: true
@@ -536,7 +536,7 @@ Clicking a notification deep-links directly to the relevant session/PR in the da
 ### Minimal Config (works out of the box)
 
 ```yaml
-# agent-orchestrator.yaml
+# syntese.yaml
 projects:
   my-app:
     repo: org/repo
@@ -556,8 +556,8 @@ Everything else uses sensible defaults:
 ### Full Config
 
 ```yaml
-# agent-orchestrator.yaml
-dataDir: ~/.agent-orchestrator # metadata storage
+# syntese.yaml
+dataDir: ~/.syntese # metadata storage
 worktreeDir: ~/.worktrees # workspace root
 port: 3000 # web dashboard port
 
@@ -646,13 +646,13 @@ reactions:
 | **Config**          | YAML + Zod validation                   | Human-readable, type-safe                            |
 | **State**           | Flat metadata files + Event log (JSONL) | Stateless orchestrator, crash recovery               |
 | **Package manager** | pnpm workspaces                         | Fast, monorepo-native                                |
-| **Distribution**    | npm (`npx agent-orchestrator`)          | Zero install                                         |
+| **Distribution**    | npm (`npx syntese`)                     | Zero install                                         |
 
 ### Why TypeScript Throughout
 
 1. **One language** — Plugin authors only need TypeScript/JavaScript
 2. **Shared types** — No serialization boundaries between core, web, CLI, plugins
-3. **npm distribution** — `npx agent-orchestrator` works everywhere
+3. **npm distribution** — `npx syntese` works everywhere
 4. **Next.js** — Web + API server in one process, great DX
 5. **Largest ecosystem** — More packages on npm than any other registry
 6. **Performance is fine** — Bottleneck is AI agents, not orchestrator. We shell out to tmux/git/docker anyway.
@@ -662,11 +662,11 @@ reactions:
 ## Directory Structure
 
 ```
-agent-orchestrator/
+syntese/
 ├── package.json
 ├── pnpm-workspace.yaml
 ├── tsconfig.base.json
-├── agent-orchestrator.yaml.example
+├── syntese.yaml.example
 │
 ├── packages/
 │   ├── core/                          # @composio/ao-core

--- a/artifacts/implementation-plan.md
+++ b/artifacts/implementation-plan.md
@@ -47,7 +47,7 @@ Creates the monorepo scaffold and ALL type definitions. After this, every agent 
 5. `packages/core/package.json` + `tsconfig.json`
 6. All plugin package scaffolds (package.json + tsconfig + src/index.ts stub)
 7. `packages/cli/package.json` + `packages/web/package.json` scaffolds
-8. `agent-orchestrator.yaml.example`
+8. `syntese.yaml.example`
 
 **Estimated effort**: Medium. ~500-800 lines of types + config.
 
@@ -143,7 +143,7 @@ Creates the monorepo scaffold and ALL type definitions. After this, every agent 
 
 | Command                                | What                                                 | Reference Script                    |
 | -------------------------------------- | ---------------------------------------------------- | ----------------------------------- |
-| `ao init`                              | Interactive setup wizard → `agent-orchestrator.yaml` | New                                 |
+| `ao init`                              | Interactive setup wizard → `syntese.yaml` | New                                 |
 | `ao status`                            | Colored terminal table of all sessions               | `claude-status`                     |
 | `ao spawn <project> [issue]`           | Spawn single session                                 | `claude-spawn`                      |
 | `ao batch-spawn <project> <issues...>` | Batch spawn with dedup                               | `claude-batch-spawn`                |

--- a/changelog/hash-based-architecture-migration.md
+++ b/changelog/hash-based-architecture-migration.md
@@ -6,12 +6,12 @@
 
 ## What Changed
 
-Agent Orchestrator has migrated from flat, configurable directories (`dataDir` and `worktreeDir`) to a **hash-based project isolation** architecture. This change eliminates configuration overhead and prevents collisions when running multiple orchestrator instances from different directories.
+Syntese has migrated from flat, configurable directories (`dataDir` and `worktreeDir`) to a **hash-based project isolation** architecture. This change eliminates configuration overhead and prevents collisions when running multiple orchestrator instances from different directories.
 
 ### Before (Flat Architecture)
 
 ```yaml
-# agent-orchestrator.yaml
+# syntese.yaml
 dataDir: ~/.ao-sessions
 worktreeDir: ~/.ao-worktrees
 
@@ -30,7 +30,7 @@ projects:
 ### After (Hash-Based Architecture)
 
 ```yaml
-# agent-orchestrator.yaml
+# syntese.yaml
 # No dataDir or worktreeDir needed!
 
 projects:
@@ -49,10 +49,10 @@ projects:
 
 ### Directory Structure
 
-All orchestrator data now lives under `~/.agent-orchestrator/`:
+All orchestrator data now lives under `~/.syntese/`:
 
 ```
-~/.agent-orchestrator/
+~/.syntese/
 ├── {hash}-{projectId}/        # Unique per config+project
 │   ├── .origin                # Stores config path (collision detection)
 │   ├── sessions/              # Session metadata
@@ -69,11 +69,11 @@ All orchestrator data now lives under `~/.agent-orchestrator/`:
 The hash is the first 12 characters of `SHA256(realpath(dirname(configPath)))`:
 
 ```typescript
-// Config at: ~/projects/acme/agent-orchestrator.yaml
+// Config at: ~/projects/acme/syntese.yaml
 // Hash of:   /Users/you/projects/acme
 // Result:    a3b4c5d6e7f8
 
-// Final path: ~/.agent-orchestrator/a3b4c5d6e7f8-my-app/
+// Final path: ~/.syntese/a3b4c5d6e7f8-my-app/
 ```
 
 **Why 12 chars?** Balance between uniqueness (collision probability ~1 in 16 billion) and path length.
@@ -102,7 +102,7 @@ Three levels of naming for compatibility:
 **Migration**:
 
 ```diff
-# agent-orchestrator.yaml
+# syntese.yaml
 - dataDir: ~/.ao-sessions
 - worktreeDir: ~/.ao-worktrees
 
@@ -126,7 +126,7 @@ projects:
 **After**:
 
 ```
-~/.agent-orchestrator/
+~/.syntese/
 ├── a3b4c5d6e7f8-integrator/sessions/
 │   ├── int-1      # Integrator project sessions
 │   └── int-2
@@ -154,7 +154,7 @@ projects:
 **After**:
 
 ```
-~/.agent-orchestrator/
+~/.syntese/
 ├── a3b4c5d6e7f8-integrator/worktrees/
 │   ├── int-1
 │   └── int-2
@@ -176,7 +176,7 @@ AO_DATA_DIR=~/.ao-sessions          # Flat path
 **After**:
 
 ```bash
-AO_DATA_DIR=~/.agent-orchestrator/a3b4c5d6e7f8-integrator/sessions/
+AO_DATA_DIR=~/.syntese/a3b4c5d6e7f8-integrator/sessions/
 ```
 
 **Impact**: Scripts or hooks relying on `AO_DATA_DIR` pointing to a flat directory will break.
@@ -217,8 +217,8 @@ const worktreesDir = getWorktreesDir(configPath, projectPath);
 Remove `dataDir` and `worktreeDir` from your config:
 
 ```bash
-# Edit your agent-orchestrator.yaml
-vim ~/path/to/agent-orchestrator.yaml
+# Edit your syntese.yaml
+vim ~/path/to/syntese.yaml
 ```
 
 Remove these lines:
@@ -307,7 +307,7 @@ ao spawn my-app INT-1234
 
 ```bash
 # Check that new directories were created
-ls -la ~/.agent-orchestrator/
+ls -la ~/.syntese/
 
 # You should see directories like:
 # a3b4c5d6e7f8-my-app/
@@ -335,7 +335,7 @@ If you need to rollback to the old architecture:
 2. **Restore old config**:
 
    ```bash
-   # Add back to agent-orchestrator.yaml
+   # Add back to syntese.yaml
    dataDir: ~/.ao-sessions
    worktreeDir: ~/.ao-worktrees
    ```
@@ -355,7 +355,7 @@ If you need to rollback to the old architecture:
 
 ### Q: Why can't I use my old sessions?
 
-**A**: The metadata file structure changed. Old sessions point to flat directories (`~/.ao-sessions/int-1`) but the new code expects hash-based paths (`~/.agent-orchestrator/a3b4c5d6e7f8-integrator/sessions/int-1`). You must kill old sessions and spawn new ones.
+**A**: The metadata file structure changed. Old sessions point to flat directories (`~/.ao-sessions/int-1`) but the new code expects hash-based paths (`~/.syntese/a3b4c5d6e7f8-integrator/sessions/int-1`). You must kill old sessions and spawn new ones.
 
 ### Q: Will my PRs be lost?
 
@@ -379,7 +379,7 @@ If you need to rollback to the old architecture:
 ```bash
 # For each project
 OLD_DIR=~/.ao-sessions
-NEW_DIR=~/.agent-orchestrator/$(python3 -c "import hashlib; print(hashlib.sha256(b'/Users/you/path/to/config/dir').hexdigest()[:12])")-integrator/sessions
+NEW_DIR=~/.syntese/$(python3 -c "import hashlib; print(hashlib.sha256(b'/Users/you/path/to/config/dir').hexdigest()[:12])")-integrator/sessions
 
 mkdir -p "$NEW_DIR"
 
@@ -388,7 +388,7 @@ cp "$OLD_DIR"/int-* "$NEW_DIR/"
 
 # Update worktree paths in each file (required!)
 for file in "$NEW_DIR"/*; do
-  sed -i '' 's|worktree=~/.ao-worktrees/integrator/|worktree=~/.agent-orchestrator/HASH-integrator/worktrees/|g' "$file"
+  sed -i '' 's|worktree=~/.ao-worktrees/integrator/|worktree=~/.syntese/HASH-integrator/worktrees/|g' "$file"
 done
 ```
 
@@ -399,13 +399,13 @@ This is error-prone. **Recommended**: Kill old sessions and spawn fresh ones.
 **A**: Each config gets a unique hash! This is the **main benefit** of the new architecture:
 
 ```bash
-# Config 1: ~/projects/acme/agent-orchestrator.yaml
+# Config 1: ~/projects/acme/syntese.yaml
 # Hash: a3b4c5d6e7f8
-# Sessions: ~/.agent-orchestrator/a3b4c5d6e7f8-my-app/
+# Sessions: ~/.syntese/a3b4c5d6e7f8-my-app/
 
-# Config 2: ~/experiments/test/agent-orchestrator.yaml
+# Config 2: ~/experiments/test/syntese.yaml
 # Hash: 1f2e3d4c5b6a
-# Sessions: ~/.agent-orchestrator/1f2e3d4c5b6a-my-app/
+# Sessions: ~/.syntese/1f2e3d4c5b6a-my-app/
 ```
 
 No conflicts, complete isolation!
@@ -421,7 +421,7 @@ echo -n "/path/to/your/config/dir" | sha256sum | cut -c1-12
 # Or let ao print it
 ao status
 # Output shows: Config: /path/to/config.yaml
-# Hash will be in directory names: ~/.agent-orchestrator/{hash}-{project}/
+# Hash will be in directory names: ~/.syntese/{hash}-{project}/
 ```
 
 ### Q: What if two configs have the same hash (collision)?
@@ -430,9 +430,9 @@ ao status
 
 ```
 Hash collision detected!
-Directory: ~/.agent-orchestrator/a3b4c5d6e7f8-my-app
-Expected config: /Users/you/config1/agent-orchestrator.yaml
-Actual config: /Users/you/config2/agent-orchestrator.yaml
+Directory: ~/.syntese/a3b4c5d6e7f8-my-app
+Expected config: /Users/you/config1/syntese.yaml
+Actual config: /Users/you/config2/syntese.yaml
 This is a rare hash collision. Please move one of the configs to a different directory.
 ```
 
@@ -443,12 +443,12 @@ This is a rare hash collision. Please move one of the configs to a different dir
 If you encounter issues during migration:
 
 1. Check existing sessions: `tmux ls`
-2. Check new directory structure: `ls -la ~/.agent-orchestrator/`
+2. Check new directory structure: `ls -la ~/.syntese/`
 3. Check config validation: `ao status`
 4. Review git worktrees: `git worktree list` (from project directory)
 5. Check logs: `journalctl -u ao-orchestrator` or tmux session output
 
-For bugs or questions, file an issue: https://github.com/composiohq/agent-orchestrator/issues
+For bugs or questions, file an issue: https://github.com/sigvardt/syntese/issues
 
 ## Summary
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -12,8 +12,8 @@
 
 ```bash
 # Clone the repository
-git clone https://github.com/ComposioHQ/agent-orchestrator.git
-cd agent-orchestrator
+git clone https://github.com/sigvardt/syntese.git
+cd syntese
 
 # Install dependencies
 pnpm install
@@ -22,10 +22,10 @@ pnpm install
 pnpm build
 
 # Copy example config
-cp agent-orchestrator.yaml.example agent-orchestrator.yaml
+cp syntese.yaml.example syntese.yaml
 
 # Configure your settings
-$EDITOR agent-orchestrator.yaml
+$EDITOR syntese.yaml
 ```
 
 ### Running the Dev Server
@@ -55,7 +55,7 @@ ao services status --strict
 ### Project Structure
 
 ```
-agent-orchestrator/
+syntese/
 ├── packages/
 │   ├── core/              # Core types, services, config
 │   ├── cli/               # CLI tool (ao command)
@@ -69,7 +69,7 @@ agent-orchestrator/
 │   │   ├── notifier-*/    # Notification channels
 │   │   └── terminal-*/    # Terminal UIs
 │   └── integration-tests/ # Integration tests
-├── agent-orchestrator.yaml.example
+├── syntese.yaml.example
 ├── .gitleaks.toml         # Secret scanning config
 ├── .husky/                # Git hooks
 └── docs/                  # Documentation
@@ -189,7 +189,7 @@ pnpm install
 pnpm build
 
 # Copy config
-cp ../agent-orchestrator/agent-orchestrator.yaml .
+cp ../syntese/syntese.yaml .
 
 # Start dev server
 cd packages/web
@@ -322,7 +322,7 @@ tmux attach -t session-name
 **Inspect session metadata:**
 
 ```bash
-cat ~/.agent-orchestrator/my-app-3
+cat ~/.syntese/my-app-3
 ```
 
 **Check session status:**
@@ -383,10 +383,10 @@ pnpm build
 
 ### Web Dashboard 404s
 
-The web app expects `agent-orchestrator.yaml` in working directory:
+The web app expects `syntese.yaml` in working directory:
 
 ```bash
-cp agent-orchestrator.yaml.example agent-orchestrator.yaml
+cp syntese.yaml.example syntese.yaml
 ```
 
 ### Permission Errors in Tests
@@ -420,4 +420,4 @@ import { foo } from "./bar";
 - [CLAUDE.md](../CLAUDE.md) — Code conventions and architecture
 - [SECURITY.md](../SECURITY.md) — Security best practices
 - [packages/core/README.md](../packages/core/README.md) — Core architecture
-- [agent-orchestrator.yaml.example](../agent-orchestrator.yaml.example) — Config reference
+- [syntese.yaml.example](../syntese.yaml.example) — Config reference

--- a/docs/SECURITY-AUDIT-SUMMARY.md
+++ b/docs/SECURITY-AUDIT-SUMMARY.md
@@ -1,4 +1,4 @@
-# Security Audit Summary — Agent Orchestrator
+# Security Audit Summary — Syntese
 
 **Date**: 2026-02-16
 **Auditor**: Claude Sonnet 4.5
@@ -23,7 +23,7 @@
 **Issue**: OpenClaw notifier token found in git history
 
 - **Token**: `1af5c4f...872` (redacted - visible in commit history)
-- **File**: `agent-orchestrator.yaml`
+- **File**: `syntese.yaml`
 - **Commit**: `0393ab70a83e090883895d2168aa39a76f997ec8`
 - **Date**: 2026-02-15
 - **Status**: Token already removed from current code, still in git history
@@ -117,7 +117,7 @@ To fix:
   1. Remove the secret from the file
   2. Use environment variables instead: ${SECRET_NAME}
   3. Add to .env.local (which is in .gitignore)
-  4. Update agent-orchestrator.yaml.example with placeholder values
+  4. Update syntese.yaml.example with placeholder values
 
 If this is a false positive, update .gitleaks.toml allowlist
 ```
@@ -202,10 +202,10 @@ id_ed25519
 *.ppk
 
 # Local config (may contain secrets)
-agent-orchestrator.yaml
+syntese.yaml
 ```
 
-**Critical**: `agent-orchestrator.yaml` is now ignored because it contains user secrets
+**Critical**: `syntese.yaml` is now ignored because it contains user secrets
 
 ### 5. Documentation
 
@@ -344,7 +344,7 @@ Finding: OpenClaw token in commit 0393ab70 (documented)
 
 ## Conclusion
 
-✅ **Agent Orchestrator is now protected against secret leaks**
+✅ **Syntese is now protected against secret leaks**
 
 The codebase is currently clean, with one historical secret that needs rotation. Comprehensive automated scanning prevents future accidents. All developers are protected by pre-commit hooks, and CI/CD ensures nothing reaches the main branch.
 

--- a/docs/design/design-brief-v1.md
+++ b/docs/design/design-brief-v1.md
@@ -1,11 +1,11 @@
-# Agent Orchestrator Dashboard — Design Brief
+# Syntese Dashboard — Design Brief
 *Research-backed design specification for the ao dashboard*
 
 ---
 
 ## Product Context
 
-The Agent Orchestrator dashboard is **mission control for parallel AI coding agents**. Users are senior engineers and CTOs who routinely spawn 10–30 agents at once and need to:
+The Syntese dashboard is **mission control for parallel AI coding agents**. Users are senior engineers and CTOs who routinely spawn 10–30 agents at once and need to:
 
 1. Triage at a glance (who needs me right now?)
 2. Merge PRs that are ready

--- a/docs/design/design-brief.md
+++ b/docs/design/design-brief.md
@@ -1,4 +1,4 @@
-# Agent Orchestrator Dashboard — Design Brief
+# Syntese Dashboard — Design Brief
 *Research-backed design specification for the ao dashboard*
 *Version 2 — Updated with Playwright CSS extraction from live sites*
 
@@ -6,7 +6,7 @@
 
 ## Product Context
 
-The Agent Orchestrator dashboard is **mission control for parallel AI coding agents**. Users are senior engineers and CTOs who routinely spawn 10–30 agents at once and need to:
+The Syntese dashboard is **mission control for parallel AI coding agents**. Users are senior engineers and CTOs who routinely spawn 10–30 agents at once and need to:
 
 1. Triage at a glance (who needs me right now?)
 2. Merge PRs that are ready

--- a/docs/design/feedback-routing-and-followup-design.md
+++ b/docs/design/feedback-routing-and-followup-design.md
@@ -160,8 +160,8 @@ Minimal journal schema example:
   "status": "failed",
   "attempt": 2,
   "operationKey": "create_pr:f4d7dbe5b0f8:upstream",
-  "targetRepo": "ComposioHQ/agent-orchestrator",
-  "issueUrl": "https://github.com/ComposioHQ/agent-orchestrator/issues/399",
+  "targetRepo": "sigvardt/syntese",
+  "issueUrl": "https://github.com/sigvardt/syntese/issues/399",
   "prUrl": null,
   "consent": {
     "createFork": "approved",

--- a/docs/design/orchestrator-terminal-design-brief.md
+++ b/docs/design/orchestrator-terminal-design-brief.md
@@ -29,7 +29,7 @@ The orchestrator terminal page should diverge from the generic session detail la
 
 ```
 ┌─ Nav bar ───────────────────────────────────────────────────────────────┐
-│  ← Agent Orchestrator                                     orchestrator  │
+│  ← Syntese                                     orchestrator  │
 └─────────────────────────────────────────────────────────────────────────┘
 
 ┌─ Status strip ──────────────────────────────────────────────────────────┐
@@ -76,7 +76,7 @@ These three changes are purely visual and require no structural changes to share
 Same as session detail bar, plus a persistent right-side label:
 
 ```
-← Agent Orchestrator                                    [orchestrator]
+← Syntese                                    [orchestrator]
 ```
 
 ```css

--- a/docs/design/session-detail-design-brief.md
+++ b/docs/design/session-detail-design-brief.md
@@ -24,7 +24,7 @@ The session detail page is a **single-task focused view**, not a dashboard. The 
 
 ```
 ┌─ Nav bar ───────────────────────────────────────────────────────────────┐
-│  ← Agent Orchestrator                                                   │
+│  ← Syntese                                                   │
 └─────────────────────────────────────────────────────────────────────────┘
 
 ┌─ Header ────────────────────────────────────────────────────────────────┐
@@ -82,11 +82,11 @@ border-bottom: 1px solid var(--border-subtle);
 padding: 0 32px;
 ```
 
-**Back link**: `← Agent Orchestrator` in `--text-secondary`. On hover: `--text-primary`. No underline, `tracking-wide`.
+**Back link**: `← Syntese` in `--text-secondary`. On hover: `--text-primary`. No underline, `tracking-wide`.
 
 **Addition (not currently present)**: Show current session ID as a breadcrumb:
 ```
-← Agent Orchestrator  /  ao-58
+← Syntese  /  ao-58
 ```
 `ao-58` in monospace, `--text-muted`. Helps orient the user without reading the header.
 
@@ -295,7 +295,7 @@ Recommended:
 
 | Priority | Change | File | Notes |
 |----------|--------|------|-------|
-| 1 | Breadcrumb in nav: `← Agent Orchestrator / ao-58` | `SessionDetail.tsx` | Orientation |
+| 1 | Breadcrumb in nav: `← Syntese / ao-58` | `SessionDetail.tsx` | Orientation |
 | 2 | Activity indicator: CSS dot instead of emoji | `SessionDetail.tsx` — `activityLabel` map | Visual precision |
 | 3 | "Ready to merge" → banner card instead of text line | `SessionDetail.tsx` — `PRCard` | Primary action prominence |
 | 4 | Terminal theme: `#0A0A0F` bg, `#5B7EF8` cursor, JetBrains Mono | `DirectTerminal.tsx` | Terminal quality |

--- a/docs/opencode-workflows-spec.md
+++ b/docs/opencode-workflows-spec.md
@@ -1,6 +1,6 @@
-# OpenCode Workflow Spec (Agent Orchestrator)
+# OpenCode Workflow Spec (Syntese)
 
-This document defines intended behavior for Agent Orchestrator when `agent: opencode` is selected, including edge cases and expected outcomes.
+This document defines intended behavior for Syntese when `agent: opencode` is selected, including edge cases and expected outcomes.
 
 ## Scope
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,14 +1,16 @@
-# Agent Orchestrator Config Examples
+# Syntese Config Examples
 
 This directory contains example configurations for common use cases.
+
+`ao` remains the backward-compatible CLI alias, so the examples below continue to use `ao`.
 
 ## Quick Start
 
 Copy an example and customize:
 
 ```bash
-cp examples/simple-github.yaml agent-orchestrator.yaml
-nano agent-orchestrator.yaml  # edit as needed
+cp examples/simple-github.yaml syntese.yaml
+nano syntese.yaml  # edit as needed
 ao spawn my-app ISSUE-123
 ```
 

--- a/examples/auto-merge.yaml
+++ b/examples/auto-merge.yaml
@@ -1,7 +1,7 @@
 # Aggressive automation with auto-merge
 # Automatically merges approved PRs with passing CI
 
-dataDir: ~/.agent-orchestrator
+dataDir: ~/.syntese
 worktreeDir: ~/.worktrees
 
 projects:

--- a/examples/codex-integration.yaml
+++ b/examples/codex-integration.yaml
@@ -1,7 +1,7 @@
 # Using Codex instead of Claude Code
 # Demonstrates using a different AI agent
 
-dataDir: ~/.agent-orchestrator
+dataDir: ~/.syntese
 worktreeDir: ~/.worktrees
 
 defaults:

--- a/examples/linear-team.yaml
+++ b/examples/linear-team.yaml
@@ -1,7 +1,7 @@
 # Linear integration with custom team
 # Requires LINEAR_API_KEY environment variable
 
-dataDir: ~/.agent-orchestrator
+dataDir: ~/.syntese
 worktreeDir: ~/.worktrees
 
 projects:

--- a/examples/multi-project.yaml
+++ b/examples/multi-project.yaml
@@ -1,7 +1,7 @@
 # Managing multiple projects with different trackers
 # Shows how to configure multiple repos with different settings
 
-dataDir: ~/.agent-orchestrator
+dataDir: ~/.syntese
 worktreeDir: ~/.worktrees
 
 defaults:

--- a/examples/simple-github.yaml
+++ b/examples/simple-github.yaml
@@ -1,7 +1,7 @@
 # Minimal setup for a single GitHub repo with GitHub Issues
 # Perfect for getting started quickly
 
-dataDir: ~/.agent-orchestrator
+dataDir: ~/.syntese
 worktreeDir: ~/.worktrees
 
 projects:

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
-# @agent-orchestrator/core
+# Syntese core package (`@agent-orchestrator/core`)
 
-Core services, types, and configuration for the Agent Orchestrator system.
+Core services, types, and configuration for Syntese. The published package name remains `@agent-orchestrator/core` until the package rename lands.
 
 ## What's Here
 
@@ -103,11 +103,11 @@ Loads plugins and provides access to them:
 
 ### `src/config.ts` — Configuration Loading
 
-Loads and validates `agent-orchestrator.yaml`:
+Loads and validates `syntese.yaml`:
 
 **Main config sections:**
 
-- `dataDir` — where session metadata lives (~/.agent-orchestrator)
+- `dataDir` — where session metadata lives (`~/.syntese`)
 - `worktreeDir` — where workspaces are created (~/.worktrees)
 - `port` — web dashboard port (default 3000, set different values for multiple projects)
 - `terminalPort` — terminal WebSocket port (auto-detected if not set)
@@ -176,7 +176,7 @@ const saved = store.persist(FEEDBACK_TOOL_NAMES.BUG_REPORT, {
 
 Storage format:
 
-- Reports are persisted under `~/.agent-orchestrator/{hash}-{projectId}/feedback-reports`
+- Reports are persisted under `~/.syntese/{hash}-{projectId}/feedback-reports`
 - Each report is a typed key=value file (`report_<timestamp>_<id>.kv`) for easy inspection
 - A deterministic dedupe key (`sha256`, 16 hex chars) is generated from normalized tool+content
 
@@ -222,7 +222,7 @@ This package is a dependency of all other packages. Build it first if working on
 
 **Why flat metadata files?**
 
-- Debuggability: `cat ~/.agent-orchestrator/my-app-3` shows full state
+- Debuggability: `cat ~/.syntese/my-app-3` shows full state
 - No database dependency (survives crashes, easy to inspect)
 - Backwards-compatible with bash script orchestrator
 

--- a/packages/plugins/notifier-openclaw/README.md
+++ b/packages/plugins/notifier-openclaw/README.md
@@ -15,7 +15,7 @@ OpenClaw notifier plugin for AO escalation events.
 }
 ```
 
-## AO config (`agent-orchestrator.yaml`)
+## AO config (`syntese.yaml`)
 
 ```yaml
 notifiers:

--- a/packages/plugins/runtime-tmux/README.md
+++ b/packages/plugins/runtime-tmux/README.md
@@ -1,4 +1,4 @@
-# @agent-orchestrator/plugin-runtime-tmux
+# Syntese tmux runtime plugin (`@agent-orchestrator/plugin-runtime-tmux`)
 
 Runtime plugin for executing agent sessions in tmux.
 

--- a/syntese.yaml.example
+++ b/syntese.yaml.example
@@ -1,8 +1,8 @@
-# Agent Orchestrator Configuration
-# Copy to agent-orchestrator.yaml and customize.
+# Syntese Configuration
+# Copy to syntese.yaml and customize.
 
 # Where to store session metadata
-dataDir: ~/.agent-orchestrator
+dataDir: ~/.syntese
 
 # Where to create workspaces (git worktrees, clones)
 worktreeDir: ~/.worktrees

--- a/test-ao-config.yaml
+++ b/test-ao-config.yaml
@@ -1,4 +1,4 @@
-dataDir: ~/.agent-orchestrator
+dataDir: ~/.syntese
 worktreeDir: ~/.worktrees
 port: 3000
 defaults:
@@ -9,7 +9,7 @@ defaults:
     - desktop
 projects:
   ao-35:
-    repo: ComposioHQ/agent-orchestrator
+    repo: sigvardt/syntese
     path: /Users/equinox/.worktrees/ao/ao/ao-35
     defaultBranch: feat/seamless-onboarding
     agentRules: >-

--- a/test-ao-config2.yaml
+++ b/test-ao-config2.yaml
@@ -1,4 +1,4 @@
-dataDir: ~/.agent-orchestrator
+dataDir: ~/.syntese
 worktreeDir: ~/.worktrees
 port: 3000
 defaults:
@@ -9,7 +9,7 @@ defaults:
     - desktop
 projects:
   ao-35:
-    repo: ComposioHQ/agent-orchestrator
+    repo: sigvardt/syntese
     path: /Users/equinox/.worktrees/ao/ao/ao-35
     defaultBranch: feat/seamless-onboarding
     agentRules: >-


### PR DESCRIPTION
## Summary
- rebrand repo docs, examples, and scoped YAML/workflow metadata from Agent Orchestrator to Syntese
- rename the tracked root config example to `syntese.yaml.example` and update example/test config content to use `syntese.yaml` and `~/.syntese`
- update fork workflow repo-name checks and the fork repo description, while noting that `ao` remains the backward-compatible CLI alias

## Verification
- `pnpm run typecheck`
- `pnpm run lint` (passes with existing warnings)
- `pnpm test` currently fails in `packages/core/src/__tests__/session-manager.test.ts` on `reuses a single OpenCode session list lookup when multiple unmapped sessions are listed`; this appears unrelated to the docs/YAML rebrand changes in this PR

Closes #49