### PR TITLE
test: rebrand test files and web UI to syntese

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -129,7 +129,7 @@ beforeEach(() => {
   consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
   // Create a temporary config file
-  configPath = join(tmpDir, "agent-orchestrator.yaml");
+  configPath = join(tmpDir, "syntese.yaml");
   writeFileSync(configPath, "projects: {}\n");
 
   mockRuntime = {
@@ -225,7 +225,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
 
-  // Clean up hash-based directories in ~/.agent-orchestrator
+  // Clean up hash-based directories in ~/.syntese
   const projectBaseDir = getProjectBaseDir(configPath, join(tmpDir, "my-app"));
   if (existsSync(projectBaseDir)) {
     rmSync(projectBaseDir, { recursive: true, force: true });
@@ -287,7 +287,7 @@ describe("progress snapshots", () => {
     mkdirSync(repoPath, { recursive: true });
     runGit(repoPath, "init");
     runGit(repoPath, "config", "user.email", "ao@example.com");
-    runGit(repoPath, "config", "user.name", "Agent Orchestrator");
+    runGit(repoPath, "config", "user.name", "Syntese");
     writeFileSync(join(repoPath, "app.txt"), "hello\n");
     runGit(repoPath, "add", "app.txt");
     runGit(repoPath, "commit", "-m", "init");

--- a/packages/core/src/__tests__/paths.test.ts
+++ b/packages/core/src/__tests__/paths.test.ts
@@ -45,7 +45,7 @@ describe("Hash Generation", () => {
   });
 
   it("produces 12-character hex string", () => {
-    const configPath = join(tmpDir, "agent-orchestrator.yaml");
+    const configPath = join(tmpDir, "syntese.yaml");
     writeFileSync(configPath, "projects: {}");
 
     const hash = generateConfigHash(configPath);
@@ -55,7 +55,7 @@ describe("Hash Generation", () => {
   });
 
   it("is deterministic - same path produces same hash", () => {
-    const configPath = join(tmpDir, "agent-orchestrator.yaml");
+    const configPath = join(tmpDir, "syntese.yaml");
     writeFileSync(configPath, "projects: {}");
 
     const hash1 = generateConfigHash(configPath);
@@ -70,8 +70,8 @@ describe("Hash Generation", () => {
     mkdirSync(dir1, { recursive: true });
     mkdirSync(dir2, { recursive: true });
 
-    const config1 = join(dir1, "agent-orchestrator.yaml");
-    const config2 = join(dir2, "agent-orchestrator.yaml");
+    const config1 = join(dir1, "syntese.yaml");
+    const config2 = join(dir2, "syntese.yaml");
     writeFileSync(config1, "projects: {}");
     writeFileSync(config2, "projects: {}");
 
@@ -86,12 +86,12 @@ describe("Hash Generation", () => {
     const symlinkDir = join(tmpDir, "symlink");
     mkdirSync(realDir, { recursive: true });
 
-    const realConfig = join(realDir, "agent-orchestrator.yaml");
+    const realConfig = join(realDir, "syntese.yaml");
     writeFileSync(realConfig, "projects: {}");
 
     // Create symlink to directory
     symlinkSync(realDir, symlinkDir);
-    const symlinkConfig = join(symlinkDir, "agent-orchestrator.yaml");
+    const symlinkConfig = join(symlinkDir, "syntese.yaml");
 
     const hashReal = generateConfigHash(realConfig);
     const hashSymlink = generateConfigHash(symlinkConfig);
@@ -128,7 +128,7 @@ describe("Instance ID Generation", () => {
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "instance-test-"));
-    configPath = join(tmpDir, "agent-orchestrator.yaml");
+    configPath = join(tmpDir, "syntese.yaml");
     writeFileSync(configPath, "projects: {}");
   });
 
@@ -166,7 +166,7 @@ describe("Instance ID Generation", () => {
   it("different config + same project = different instance IDs", () => {
     const otherDir = join(tmpdir(), "other-config-test");
     mkdirSync(otherDir, { recursive: true });
-    const config2Path = join(otherDir, "agent-orchestrator.yaml");
+    const config2Path = join(otherDir, "syntese.yaml");
     writeFileSync(config2Path, "projects: {}");
 
     const id1 = generateInstanceId(configPath, "/repos/integrator");
@@ -203,7 +203,7 @@ describe("Session Prefix Generation", () => {
 
   describe("kebab-case", () => {
     it("uses initials", () => {
-      expect(generateSessionPrefix("agent-orchestrator")).toBe("ao");
+      expect(generateSessionPrefix("syntese-platform")).toBe("sp");
       expect(generateSessionPrefix("my-app")).toBe("ma");
       expect(generateSessionPrefix("safe-split")).toBe("ss");
     });
@@ -212,7 +212,7 @@ describe("Session Prefix Generation", () => {
   describe("snake_case", () => {
     it("uses initials", () => {
       expect(generateSessionPrefix("my_project")).toBe("mp");
-      expect(generateSessionPrefix("agent_orchestrator")).toBe("ao");
+      expect(generateSessionPrefix("syntese_platform")).toBe("sp");
     });
   });
 
@@ -221,6 +221,7 @@ describe("Session Prefix Generation", () => {
       expect(generateSessionPrefix("integrator")).toBe("int");
       expect(generateSessionPrefix("backend")).toBe("bac");
       expect(generateSessionPrefix("frontend")).toBe("fro");
+      expect(generateSessionPrefix("syntese")).toBe("syn");
     });
   });
 
@@ -241,12 +242,13 @@ describe("Session Prefix Generation", () => {
 });
 
 describe("Path Construction", () => {
+  const projectBaseDirPattern = String.raw`(?:\.agent-orchestrator|\.syntese)\/[a-f0-9]{12}-integrator`;
   let tmpDir: string;
   let configPath: string;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "path-construct-"));
-    configPath = join(tmpDir, "agent-orchestrator.yaml");
+    configPath = join(tmpDir, "syntese.yaml");
     writeFileSync(configPath, "projects: {}");
   });
 
@@ -257,37 +259,37 @@ describe("Path Construction", () => {
   it("getProjectBaseDir returns correct format", () => {
     const baseDir = getProjectBaseDir(configPath, "/repos/integrator");
 
-    expect(baseDir).toMatch(/^.*\/.agent-orchestrator\/[a-f0-9]{12}-integrator$/);
+    expect(baseDir).toMatch(new RegExp(`^.*\\/${projectBaseDirPattern}$`));
   });
 
   it("getSessionsDir returns {baseDir}/sessions", () => {
     const sessionsDir = getSessionsDir(configPath, "/repos/integrator");
 
-    expect(sessionsDir).toMatch(/\.agent-orchestrator\/[a-f0-9]{12}-integrator\/sessions$/);
+    expect(sessionsDir).toMatch(new RegExp(`${projectBaseDirPattern}\\/sessions$`));
   });
 
   it("getWorktreesDir returns {baseDir}/worktrees", () => {
     const worktreesDir = getWorktreesDir(configPath, "/repos/integrator");
 
-    expect(worktreesDir).toMatch(/\.agent-orchestrator\/[a-f0-9]{12}-integrator\/worktrees$/);
+    expect(worktreesDir).toMatch(new RegExp(`${projectBaseDirPattern}\\/worktrees$`));
   });
 
   it("getFeedbackReportsDir returns {baseDir}/feedback-reports", () => {
     const reportsDir = getFeedbackReportsDir(configPath, "/repos/integrator");
 
-    expect(reportsDir).toMatch(/\.agent-orchestrator\/[a-f0-9]{12}-integrator\/feedback-reports$/);
+    expect(reportsDir).toMatch(new RegExp(`${projectBaseDirPattern}\\/feedback-reports$`));
   });
 
   it("getArchiveDir returns {baseDir}/sessions/archive", () => {
     const archiveDir = getArchiveDir(configPath, "/repos/integrator");
 
-    expect(archiveDir).toMatch(/\.agent-orchestrator\/[a-f0-9]{12}-integrator\/sessions\/archive$/);
+    expect(archiveDir).toMatch(new RegExp(`${projectBaseDirPattern}\\/sessions\\/archive$`));
   });
 
   it("getOriginFilePath returns {baseDir}/.origin", () => {
     const originPath = getOriginFilePath(configPath, "/repos/integrator");
 
-    expect(originPath).toMatch(/\.agent-orchestrator\/[a-f0-9]{12}-integrator\/\.origin$/);
+    expect(originPath).toMatch(new RegExp(`${projectBaseDirPattern}\\/\\.origin$`));
   });
 
   it("all paths share the same base directory", () => {
@@ -342,7 +344,7 @@ describe("Tmux Naming", () => {
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "tmux-naming-"));
-    configPath = join(tmpDir, "agent-orchestrator.yaml");
+    configPath = join(tmpDir, "syntese.yaml");
     writeFileSync(configPath, "projects: {}");
   });
 
@@ -416,7 +418,7 @@ describe("Origin File Management", () => {
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "origin-test-"));
-    configPath = join(tmpDir, "agent-orchestrator.yaml");
+    configPath = join(tmpDir, "syntese.yaml");
     projectPath = join(tmpDir, "project");
     writeFileSync(configPath, "projects: {}");
     mkdtempSync(projectPath);

--- a/packages/core/src/__tests__/plugin-integration.test.ts
+++ b/packages/core/src/__tests__/plugin-integration.test.ts
@@ -113,7 +113,7 @@ beforeEach(() => {
   mkdirSync(tmpDir, { recursive: true });
 
   // Create a temporary config file
-  configPath = join(tmpDir, "agent-orchestrator.yaml");
+  configPath = join(tmpDir, "syntese.yaml");
   writeFileSync(configPath, "projects: {}\n");
 
   // Initialize project with tmpDir-based path

--- a/packages/core/src/__tests__/recovery-actions.test.ts
+++ b/packages/core/src/__tests__/recovery-actions.test.ts
@@ -17,7 +17,7 @@ import type { OrchestratorConfig, PluginRegistry } from "../types.js";
 
 function makeConfig(rootDir: string): OrchestratorConfig {
   return {
-    configPath: join(rootDir, "agent-orchestrator.yaml"),
+    configPath: join(rootDir, "syntese.yaml"),
     port: 3000,
     readyThresholdMs: 300_000,
     defaults: {
@@ -96,7 +96,7 @@ function makeAssessment(overrides: Partial<RecoveryAssessment> = {}): RecoveryAs
 
 function makeContext(rootDir: string, overrides: Partial<RecoveryContext> = {}): RecoveryContext {
   return {
-    configPath: join(rootDir, "agent-orchestrator.yaml"),
+    configPath: join(rootDir, "syntese.yaml"),
     recoveryConfig: {
       ...DEFAULT_RECOVERY_CONFIG,
       logPath: join(rootDir, "recovery.log"),
@@ -119,7 +119,7 @@ describe("recoverSession", () => {
     rootDir = join(tmpdir(), `ao-recovery-${randomUUID()}`);
     mkdirSync(rootDir, { recursive: true });
     mkdirSync(join(rootDir, "project"), { recursive: true });
-    writeFileSync(join(rootDir, "agent-orchestrator.yaml"), "projects: {}\n", "utf-8");
+    writeFileSync(join(rootDir, "syntese.yaml"), "projects: {}\n", "utf-8");
 
     const config = makeConfig(rootDir);
     const registry = makeRegistry();
@@ -140,7 +140,7 @@ describe("recoverSession", () => {
     rootDir = join(tmpdir(), `ao-recovery-${randomUUID()}`);
     mkdirSync(rootDir, { recursive: true });
     mkdirSync(join(rootDir, "project"), { recursive: true });
-    writeFileSync(join(rootDir, "agent-orchestrator.yaml"), "projects: {}\n", "utf-8");
+    writeFileSync(join(rootDir, "syntese.yaml"), "projects: {}\n", "utf-8");
 
     const config = makeConfig(rootDir);
     const registry = makeRegistry();
@@ -169,7 +169,7 @@ describe("recoverSession", () => {
     rootDir = join(tmpdir(), `ao-recovery-${randomUUID()}`);
     mkdirSync(rootDir, { recursive: true });
     mkdirSync(join(rootDir, "project"), { recursive: true });
-    writeFileSync(join(rootDir, "agent-orchestrator.yaml"), "projects: {}\n", "utf-8");
+    writeFileSync(join(rootDir, "syntese.yaml"), "projects: {}\n", "utf-8");
 
     const config = makeConfig(rootDir);
     const registry = makeRegistry();
@@ -210,7 +210,7 @@ describe("escalateSession", () => {
     rootDir = join(tmpdir(), `ao-recovery-${randomUUID()}`);
     mkdirSync(rootDir, { recursive: true });
     mkdirSync(join(rootDir, "project"), { recursive: true });
-    writeFileSync(join(rootDir, "agent-orchestrator.yaml"), "projects: {}\n", "utf-8");
+    writeFileSync(join(rootDir, "syntese.yaml"), "projects: {}\n", "utf-8");
 
     const config = makeConfig(rootDir);
     const registry = makeRegistry();
@@ -242,7 +242,7 @@ describe("recovery manager and scanner", () => {
     rootDir = join(tmpdir(), `ao-recovery-${randomUUID()}`);
     mkdirSync(rootDir, { recursive: true });
     mkdirSync(join(rootDir, "project"), { recursive: true });
-    writeFileSync(join(rootDir, "agent-orchestrator.yaml"), "projects: {}\n", "utf-8");
+    writeFileSync(join(rootDir, "syntese.yaml"), "projects: {}\n", "utf-8");
 
     const config = makeConfig(rootDir);
     const sessionsDir = getSessionsDir(config.configPath, config.projects.app.path);
@@ -276,7 +276,7 @@ describe("recovery manager and scanner", () => {
     rootDir = join(tmpdir(), `ao-recovery-${randomUUID()}`);
     mkdirSync(rootDir, { recursive: true });
     mkdirSync(join(rootDir, "project"), { recursive: true });
-    writeFileSync(join(rootDir, "agent-orchestrator.yaml"), "projects: {}\n", "utf-8");
+    writeFileSync(join(rootDir, "syntese.yaml"), "projects: {}\n", "utf-8");
 
     const config = makeConfig(rootDir);
     const sessionsDir = getSessionsDir(config.configPath, config.projects.app.path);

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -124,7 +124,7 @@ beforeEach(() => {
   mkdirSync(tmpDir, { recursive: true });
 
   // Create a temporary config file
-  configPath = join(tmpDir, "agent-orchestrator.yaml");
+  configPath = join(tmpDir, "syntese.yaml");
   writeFileSync(configPath, "projects: {}\n");
 
   mockRuntime = {
@@ -220,7 +220,7 @@ beforeEach(() => {
 
 afterEach(() => {
   process.env.PATH = originalPath;
-  // Clean up hash-based directories in ~/.agent-orchestrator
+  // Clean up hash-based directories in ~/.syntese
   const projectBaseDir = getProjectBaseDir(configPath, join(tmpDir, "my-app"));
   if (existsSync(projectBaseDir)) {
     rmSync(projectBaseDir, { recursive: true, force: true });

--- a/packages/integration-tests/src/cli-spawn-core-read-new.integration.test.ts
+++ b/packages/integration-tests/src/cli-spawn-core-read-new.integration.test.ts
@@ -95,7 +95,7 @@ describe.skipIf(!tmuxOk)("CLI-Core integration (hash-based architecture)", () =>
       },
     };
 
-    configPath = join(tmpDir, "agent-orchestrator.yaml");
+    configPath = join(tmpDir, "syntese.yaml");
     await writeFile(configPath, JSON.stringify(config, null, 2));
   }, 30_000);
 
@@ -114,7 +114,9 @@ describe.skipIf(!tmuxOk)("CLI-Core integration (hash-based architecture)", () =>
     const hash = generateConfigHash(configPath);
     const sessionsDir = getSessionsDir(configPath, repoPath);
 
-    expect(sessionsDir).toMatch(new RegExp(`\\.agent-orchestrator/${hash}-test-repo/sessions$`));
+    expect(sessionsDir).toMatch(
+      new RegExp(`\\.(agent-orchestrator|syntese)/${hash}-test-repo/sessions$`),
+    );
   });
 
   it("session metadata includes tmuxName field", () => {

--- a/packages/integration-tests/src/config-metadata-service.integration.test.ts
+++ b/packages/integration-tests/src/config-metadata-service.integration.test.ts
@@ -57,12 +57,12 @@ describe("config → metadata service integration (real filesystem)", () => {
       reactions: {},
     };
 
-    configPath = join(tmpDir, "agent-orchestrator.yaml");
+    configPath = join(tmpDir, "syntese.yaml");
     await writeFile(configPath, JSON.stringify(config, null, 2));
   });
 
   afterAll(async () => {
-    // Clean up hash-based directories in ~/.agent-orchestrator
+    // Clean up hash-based directories in ~/.syntese
     try {
       const projectBaseDir = getProjectBaseDir(configPath, repoPath);
       if (existsSync(projectBaseDir)) {
@@ -87,7 +87,7 @@ describe("config → metadata service integration (real filesystem)", () => {
   it("getSessionsDir returns hash-based path including project name", () => {
     const sessionsDir = getSessionsDir(configPath, repoPath);
 
-    expect(sessionsDir).toContain(".agent-orchestrator");
+    expect(sessionsDir).toMatch(/\.(agent-orchestrator|syntese)/);
     expect(sessionsDir).toContain("my-repo");
     expect(sessionsDir).toContain("sessions");
 

--- a/packages/integration-tests/src/notifier-composio.integration.test.ts
+++ b/packages/integration-tests/src/notifier-composio.integration.test.ts
@@ -81,7 +81,7 @@ describe("notifier-composio integration", () => {
           action: "GMAIL_SEND_EMAIL",
           params: expect.objectContaining({
             to: "admin@example.com",
-            subject: "Agent Orchestrator Notification",
+            subject: "Syntese Notification",
           }),
         }),
       );

--- a/packages/integration-tests/src/notifier-desktop.integration.test.ts
+++ b/packages/integration-tests/src/notifier-desktop.integration.test.ts
@@ -117,7 +117,7 @@ describe("notifier-desktop integration", () => {
 
       expect(mockExecFile.mock.calls[0][0]).toBe("notify-send");
       const args = mockExecFile.mock.calls[0][1] as string[];
-      expect(args).toContain("Agent Orchestrator [backend-1]");
+      expect(args).toContain("Syntese [backend-1]");
       expect(args).toContain("Test msg");
     });
 

--- a/packages/integration-tests/src/notifier-openclaw.integration.test.ts
+++ b/packages/integration-tests/src/notifier-openclaw.integration.test.ts
@@ -45,11 +45,11 @@ describe("notifier-openclaw integration", () => {
     expect(url).toBe("http://127.0.0.1:18789/hooks/agent");
 
     const body = JSON.parse(opts.body);
-    expect(body.name).toBe("AO");
+    expect(body.name).toBe("Syntese");
     expect(body.sessionKey).toBe("hook:ao:ao-12");
     expect(body.wakeMode).toBe("now");
     expect(body.deliver).toBe(true);
-    expect(body.message).toContain("[AO URGENT]");
+    expect(body.message).toContain("[SYNTESE URGENT]");
     expect(body.message).toContain("CI failed 5 times");
   });
 
@@ -73,7 +73,7 @@ describe("notifier-openclaw integration", () => {
 
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.sessionKey).toBe("hook:ao:ao-5");
-    expect(body.message).toContain("[AO ACTION] ao-5 ci.failing");
+    expect(body.message).toContain("[SYNTESE ACTION] ao-5 ci.failing");
     expect(body.message).toContain('Context: {"checkName":"lint"}');
     expect(body.message).toContain("Actions available: retry, kill");
   });

--- a/packages/mobile/app.json
+++ b/packages/mobile/app.json
@@ -1,7 +1,7 @@
 {
   "expo": {
-    "name": "Agent Orchestrator",
-    "slug": "ao-mobile",
+    "name": "Syntese",
+    "slug": "syntese-mobile",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
@@ -16,7 +16,7 @@
     ],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.composio.ao-mobile",
+      "bundleIdentifier": "com.composio.syntese.mobile",
       "infoPlist": {
         "UIBackgroundModes": [
           "fetch",
@@ -30,7 +30,7 @@
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#0d1117"
       },
-      "package": "com.composio.aomobile",
+      "package": "com.composio.syntese.mobile",
       "usesCleartextTraffic": true
     },
     "web": {
@@ -42,7 +42,7 @@
         "expo-notifications",
         {
           "color": "#f85149",
-          "defaultChannel": "ao-respond"
+          "defaultChannel": "syntese-respond"
         }
       ]
     ],

--- a/packages/mobile/src/navigation/RootNavigator.tsx
+++ b/packages/mobile/src/navigation/RootNavigator.tsx
@@ -49,7 +49,7 @@ export default function RootNavigator() {
         <Stack.Screen
           name="Home"
           component={HomeScreen}
-          options={{ title: "Agent Orchestrator" }}
+          options={{ title: "Syntese" }}
         />
         <Stack.Screen
           name="SessionDetail"

--- a/packages/mobile/src/notifications/index.ts
+++ b/packages/mobile/src/notifications/index.ts
@@ -2,7 +2,7 @@ import * as Notifications from "expo-notifications";
 import { Platform } from "react-native";
 import type { DashboardSession } from "../types";
 
-const ANDROID_CHANNEL_ID = "ao-respond";
+const ANDROID_CHANNEL_ID = "syntese-respond";
 
 /** Configure how notifications are presented when the app is in foreground */
 Notifications.setNotificationHandler({

--- a/packages/mobile/src/screens/SettingsScreen.tsx
+++ b/packages/mobile/src/screens/SettingsScreen.tsx
@@ -188,7 +188,7 @@ export default function SettingsScreen({ navigation }: Props) {
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Backend URL</Text>
           <Text style={styles.hint}>
-            Enter the URL where your AO dashboard is running.
+            Enter the URL where your Syntese dashboard is running.
           </Text>
           <Text style={styles.fieldLabel}>Dashboard API URL</Text>
           <TextInput

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -47,7 +47,7 @@ function normalizePermissionMode(
 
 /** Hook script content that updates session metadata on git/gh commands */
 const METADATA_UPDATER_SCRIPT = `#!/usr/bin/env bash
-# Metadata Updater Hook for Agent Orchestrator
+# Metadata Updater Hook for Syntese
 #
 # This PostToolUse hook automatically updates session metadata when:
 # - gh pr create: extracts PR URL and writes to metadata

--- a/packages/plugins/agent-codex/src/app-server-client.ts
+++ b/packages/plugins/agent-codex/src/app-server-client.ts
@@ -378,7 +378,7 @@ export class CodexAppServerClient extends EventEmitter {
     const result = await this.sendRequest("initialize", {
       clientInfo: {
         name: "ao-agent-codex",
-        title: "Agent Orchestrator — Codex Plugin",
+        title: "Syntese — Codex Plugin",
         version: "0.1.1",
       },
     });

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -1779,7 +1779,7 @@ describe("setupWorkspaceHooks", () => {
       (call: string[]) => typeof call[0] === "string" && call[0].endsWith("AGENTS.md"),
     );
     expect(agentsMdCall).toBeDefined();
-    expect(agentsMdCall![1]).toContain("Agent Orchestrator (ao) Session");
+    expect(agentsMdCall![1]).toContain("Syntese (ao) Session");
     expect(agentsMdCall![1]).toContain("# Existing Content");
   });
 
@@ -1801,7 +1801,7 @@ describe("setupWorkspaceHooks", () => {
       (call: string[]) => typeof call[0] === "string" && call[0].endsWith("AGENTS.md"),
     );
     expect(agentsMdCall).toBeDefined();
-    expect(agentsMdCall![1]).toContain("Agent Orchestrator (ao) Session");
+    expect(agentsMdCall![1]).toContain("Syntese (ao) Session");
   });
 
   it("uses atomic write (temp + rename) to prevent partial reads from concurrent sessions", async () => {
@@ -1837,7 +1837,7 @@ describe("setupWorkspaceHooks", () => {
       }
       if (typeof path === "string" && path.endsWith("AGENTS.md")) {
         return Promise.resolve(
-          "# Existing\n\n## Agent Orchestrator (ao) Session\n\nAlready here.\n",
+          "# Existing\n\n## Syntese (ao) Session\n\nAlready here.\n",
         );
       }
       return Promise.reject(new Error("ENOENT"));
@@ -1914,9 +1914,9 @@ describe("shell wrapper content", () => {
 
     it("validates ao_dir is an absolute path under expected locations", async () => {
       const content = await getWrapperContent("ao-metadata-helper.sh");
-      // Only allows paths under $HOME/.ao/, $HOME/.agent-orchestrator/, or /tmp/
+      // Only allows paths under $HOME/.ao/, $HOME/.syntese/, or /tmp/
       expect(content).toContain('$HOME"/.ao/*');
-      expect(content).toContain('$HOME"/.agent-orchestrator/*');
+      expect(content).toContain('$HOME"/.syntese/*');
       expect(content).toContain("/tmp/*");
     });
 

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -117,7 +117,7 @@ update_ao_metadata() {
 
   # Validate: ao_dir must be an absolute path under known ao directories or /tmp
   case "\$ao_dir" in
-    "\$HOME"/.ao/* | "\$HOME"/.agent-orchestrator/* | /tmp/*) ;;
+    "\$HOME"/.ao/* | "\$HOME"/.syntese/* | /tmp/*) ;;
     *) return 0 ;;
   esac
 
@@ -268,9 +268,9 @@ exit \$exit_code
  * and helps if the wrappers are bypassed.
  */
 const AO_AGENTS_MD_SECTION = `
-## Agent Orchestrator (ao) Session
+## Syntese (ao) Session
 
-You are running inside an Agent Orchestrator managed workspace.
+You are running inside a Syntese managed workspace.
 Session metadata is updated automatically via shell wrappers.
 
 If automatic updates fail, you can manually update metadata:
@@ -328,7 +328,7 @@ async function setupCodexWorkspace(workspacePath: string): Promise<void> {
     // File doesn't exist yet
   }
 
-  if (!existing.includes("Agent Orchestrator (ao) Session")) {
+  if (!existing.includes("Syntese (ao) Session")) {
     const content = existing
       ? existing.trimEnd() + "\n" + AO_AGENTS_MD_SECTION
       : AO_AGENTS_MD_SECTION.trimStart();

--- a/packages/plugins/notifier-composio/src/index.ts
+++ b/packages/plugins/notifier-composio/src/index.ts
@@ -31,7 +31,7 @@ const APP_TOOL_SLUG: Record<ComposioApp, string> = {
 
 const VALID_APPS = new Set<string>(["slack", "discord", "gmail"]);
 
-const GMAIL_SUBJECT = "Agent Orchestrator Notification";
+const GMAIL_SUBJECT = "Syntese Notification";
 
 interface ComposioToolkit {
   executeAction(params: {

--- a/packages/plugins/notifier-desktop/src/index.test.ts
+++ b/packages/plugins/notifier-desktop/src/index.test.ts
@@ -117,12 +117,12 @@ describe("notifier-desktop", () => {
       expect(script).toContain("URGENT");
     });
 
-    it("uses 'Agent Orchestrator' prefix for non-urgent priority", async () => {
+    it("uses 'Syntese' prefix for non-urgent priority", async () => {
       const notifier = create();
       await notifier.notify(makeEvent({ priority: "action" }));
 
       const script = mockExecFile.mock.calls[0][1][1] as string;
-      expect(script).toContain("Agent Orchestrator");
+      expect(script).toContain("Syntese");
     });
 
     it("includes sound for urgent notifications", async () => {

--- a/packages/plugins/notifier-desktop/src/index.ts
+++ b/packages/plugins/notifier-desktop/src/index.ts
@@ -31,7 +31,7 @@ function shouldPlaySound(priority: EventPriority, soundEnabled: boolean): boolea
 }
 
 function formatTitle(event: OrchestratorEvent): string {
-  const prefix = event.priority === "urgent" ? "URGENT" : "Agent Orchestrator";
+  const prefix = event.priority === "urgent" ? "URGENT" : "Syntese";
   return `${prefix} [${event.sessionId}]`;
 }
 

--- a/packages/plugins/notifier-openclaw/src/index.test.ts
+++ b/packages/plugins/notifier-openclaw/src/index.test.ts
@@ -104,6 +104,18 @@ describe("notifier-openclaw", () => {
     expect(body.message).toContain("Actions available: retry, kill");
   });
 
+  it("uses Syntese branding in the default headline and sender", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const notifier = create({ token: "tok" });
+    await notifier.notify(makeEvent());
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.name).toBe("Syntese");
+    expect(body.message).toContain("[SYNTESE URGENT]");
+  });
+
   it("post uses context sessionId when provided", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true });
     vi.stubGlobal("fetch", fetchMock);

--- a/packages/plugins/notifier-openclaw/src/index.ts
+++ b/packages/plugins/notifier-openclaw/src/index.ts
@@ -88,7 +88,7 @@ function eventHeadline(event: OrchestratorEvent): string {
     warning: "WARNING",
     info: "INFO",
   };
-  return `[AO ${priorityTag[event.priority]}] ${event.sessionId} ${event.type}`;
+  return `[SYNTESE ${priorityTag[event.priority]}] ${event.sessionId} ${event.type}`;
 }
 
 function stringifyData(data: Record<string, unknown>): string {
@@ -115,7 +115,7 @@ export function create(config?: Record<string, unknown>): Notifier {
   const token =
     (typeof config?.token === "string" ? config.token : undefined) ??
     process.env.OPENCLAW_HOOKS_TOKEN;
-  const senderName = typeof config?.name === "string" ? config.name : "AO";
+  const senderName = typeof config?.name === "string" ? config.name : "Syntese";
   const sessionKeyPrefix =
     typeof config?.sessionKeyPrefix === "string" ? config.sessionKeyPrefix : "hook:ao:";
   const wakeMode: WakeMode = config?.wakeMode === "next-heartbeat" ? "next-heartbeat" : "now";

--- a/packages/plugins/notifier-slack/src/index.test.ts
+++ b/packages/plugins/notifier-slack/src/index.test.ts
@@ -95,7 +95,7 @@ describe("notifier-slack", () => {
       await notifier.notify(makeEvent());
 
       const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-      expect(body.username).toBe("Agent Orchestrator");
+      expect(body.username).toBe("Syntese");
     });
 
     it("uses custom username when configured", async () => {

--- a/packages/plugins/notifier-slack/src/index.ts
+++ b/packages/plugins/notifier-slack/src/index.ts
@@ -133,7 +133,7 @@ async function postToWebhook(webhookUrl: string, payload: Record<string, unknown
 export function create(config?: Record<string, unknown>): Notifier {
   const webhookUrl = config?.webhookUrl as string | undefined;
   const defaultChannel = config?.channel as string | undefined;
-  const username = (config?.username as string) ?? "Agent Orchestrator";
+  const username = (config?.username as string) ?? "Syntese";
 
   if (!webhookUrl) {
     console.warn("[notifier-slack] No webhookUrl configured — notifications will be no-ops");

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -167,7 +167,7 @@ const mockLifecycleManager = {
 };
 
 const mockConfig: OrchestratorConfig = {
-  configPath: "/tmp/ao-test/agent-orchestrator.yaml",
+  configPath: "/tmp/ao-test/syntese.yaml",
   port: 3000,
   readyThresholdMs: 300_000,
   defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },

--- a/packages/web/src/__tests__/services.test.ts
+++ b/packages/web/src/__tests__/services.test.ts
@@ -72,7 +72,7 @@ describe("services", () => {
     mockCreateSessionManager.mockReset();
     mockLoadConfig.mockReset();
     mockLoadConfig.mockReturnValue({
-      configPath: "/tmp/agent-orchestrator.yaml",
+      configPath: "/tmp/syntese.yaml",
       port: 3000,
       readyThresholdMs: 300_000,
       defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
@@ -125,7 +125,7 @@ describe("pollBacklog", () => {
     mockSpawn.mockClear();
 
     mockLoadConfig.mockReturnValue({
-      configPath: "/tmp/agent-orchestrator.yaml",
+      configPath: "/tmp/syntese.yaml",
       port: 3000,
       readyThresholdMs: 300_000,
       defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
@@ -195,7 +195,7 @@ describe("pollBacklog", () => {
       {
         labels: ["agent:in-progress"],
         removeLabels: ["agent:backlog"],
-        comment: "Claimed by agent orchestrator — session spawned.",
+        comment: "Claimed by Syntese — session spawned.",
       },
       expect.objectContaining({ tracker: { plugin: "github" } }),
     );

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -19,10 +19,12 @@ const ibmPlexMono = IBM_Plex_Mono({
 
 export async function generateMetadata(): Promise<Metadata> {
   const projectName = getProjectName();
+  const defaultTitle =
+    projectName === "Syntese" ? "Syntese" : `Syntese | ${projectName}`;
   return {
     title: {
       template: `%s | ${projectName}`,
-      default: `ao | ${projectName}`,
+      default: defaultTitle,
     },
     description: "Dashboard for managing parallel AI coding agents",
   };

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -18,8 +18,10 @@ export const dynamic = "force-dynamic";
 
 export async function generateMetadata(): Promise<Metadata> {
   const projectName = getProjectName();
+  const defaultTitle =
+    projectName === "Syntese" ? "Syntese" : `Syntese | ${projectName}`;
   // Use absolute to opt out of the layout's "%s | project" template
-  return { title: { absolute: `ao | ${projectName}` } };
+  return { title: { absolute: defaultTitle } };
 }
 
 export default async function Home() {

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -221,7 +221,7 @@ export function Dashboard({
       <div className="mb-6 flex items-center justify-between border-b border-[var(--color-border-subtle)] pb-5">
         <div className="flex items-center gap-6">
           <h1 className="text-[17px] font-semibold tracking-[-0.02em] text-[var(--color-text-primary)]">
-            {projectName ?? "Orchestrator"}
+            {projectName ?? "Syntese"}
           </h1>
           <StatusLine stats={liveStats} needsAttention={needsAttention} />
         </div>

--- a/packages/web/src/lib/__tests__/usage.test.ts
+++ b/packages/web/src/lib/__tests__/usage.test.ts
@@ -115,7 +115,7 @@ describe("getDashboardUsage", () => {
     await mkdir(appPath, { recursive: true });
     await mkdir(docsPath, { recursive: true });
 
-    configPath = join(configDir, "agent-orchestrator.yaml");
+    configPath = join(configDir, "syntese.yaml");
     await writeFile(configPath, "projects: {}\n", "utf-8");
 
     config = makeConfig(configPath, { app: appPath, docs: docsPath });

--- a/packages/web/src/lib/project-name.ts
+++ b/packages/web/src/lib/project-name.ts
@@ -3,7 +3,7 @@ import { loadConfig } from "@composio/ao-core";
 
 /**
  * Load the primary project name from config.
- * Falls back to "ao" if config is unavailable.
+ * Falls back to "Syntese" if config is unavailable.
  *
  * Wrapped with React.cache() to deduplicate filesystem reads
  * within a single server render pass (layout + page + icon all
@@ -15,10 +15,10 @@ export const getProjectName = cache((): string => {
     const firstKey = Object.keys(config.projects)[0];
     if (firstKey) {
       const name = config.projects[firstKey].name ?? firstKey;
-      return name || firstKey || "ao";
+      return name || firstKey || "Syntese";
     }
   } catch {
     // Config not available
   }
-  return "ao";
+  return "Syntese";
 });

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -324,7 +324,7 @@ export async function pollBacklog(): Promise<void> {
               {
                 labels: ["agent:in-progress"],
                 removeLabels: ["agent:backlog"],
-                comment: "Claimed by agent orchestrator — session spawned.",
+                comment: "Claimed by Syntese — session spawned.",
               },
               project,
             );

--- a/test-ao-config.yaml
+++ b/test-ao-config.yaml
@@ -1,4 +1,4 @@
-dataDir: ~/.agent-orchestrator
+dataDir: ~/.syntese
 worktreeDir: ~/.worktrees
 port: 3000
 defaults:
@@ -9,7 +9,7 @@ defaults:
     - desktop
 projects:
   ao-35:
-    repo: ComposioHQ/agent-orchestrator
+    repo: ComposioHQ/syntese
     path: /Users/equinox/.worktrees/ao/ao/ao-35
     defaultBranch: feat/seamless-onboarding
     agentRules: >-

--- a/test-ao-config2.yaml
+++ b/test-ao-config2.yaml
@@ -1,4 +1,4 @@
-dataDir: ~/.agent-orchestrator
+dataDir: ~/.syntese
 worktreeDir: ~/.worktrees
 port: 3000
 defaults:
@@ -9,7 +9,7 @@ defaults:
     - desktop
 projects:
   ao-35:
-    repo: ComposioHQ/agent-orchestrator
+    repo: ComposioHQ/syntese
     path: /Users/equinox/.worktrees/ao/ao/ao-35
     defaultBranch: feat/seamless-onboarding
     agentRules: >-

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -24,7 +24,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
 WORKDIR /workspace
 
 # Copy the entire repo (simulates git clone)
-COPY . /workspace/agent-orchestrator
+COPY . /workspace/syntese
 
 # Create a test user (simulates developer's home directory)
 RUN useradd -m -s /bin/bash testuser

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -6,13 +6,13 @@ services:
       context: ../..
       dockerfile: tests/integration/Dockerfile
     container_name: ao-onboarding-test
-    command: /workspace/agent-orchestrator/tests/integration/onboarding-test.sh
+    command: /workspace/syntese/tests/integration/onboarding-test.sh
     environment:
       - NODE_ENV=test
       - CI=true
     # Mount the repo for live development (optional)
     volumes:
-      - ../..:/workspace/agent-orchestrator
+      - ../..:/workspace/syntese
     # Expose ports for debugging (optional)
     # Use 9000/9001/9003 on host to avoid conflicts with orchestrator
     # Container still uses 9000/14800/14801 internally

--- a/tests/integration/onboarding-test.sh
+++ b/tests/integration/onboarding-test.sh
@@ -33,13 +33,13 @@ fail_step() {
 
 # Test starts here
 echo -e "${BLUE}╔════════════════════════════════════════════════════════╗${NC}"
-echo -e "${BLUE}║  Agent Orchestrator - Onboarding Integration Test     ║${NC}"
+echo -e "${BLUE}║  Syntese - Onboarding Integration Test     ║${NC}"
 echo -e "${BLUE}╔════════════════════════════════════════════════════════╗${NC}"
 echo ""
 
 # Step 1: Simulate git clone (already done by Docker COPY, but we cd into it)
 start_step "Step 1: Navigate to repository"
-cd /workspace/agent-orchestrator || fail_step "Repository not found"
+cd /workspace/syntese || fail_step "Repository not found"
 end_step "Step 1: Repository accessible"
 
 # Step 2: Run setup script
@@ -65,7 +65,7 @@ git init
 git config user.email "test@example.com"
 git config user.name "Test User"
 
-cat > agent-orchestrator.yaml << 'EOF'
+cat > syntese.yaml << 'EOF'
 dataDir: /tmp/ao-test-data
 worktreeDir: /tmp/ao-test-worktrees
 port: 9000
@@ -82,7 +82,7 @@ end_step "Step 4: Configuration created"
 # Step 5: Verify config is valid
 start_step "Step 5: Validate configuration"
 # ao init would fail if run again, so we just verify the file is readable
-if [ ! -f agent-orchestrator.yaml ]; then
+if [ ! -f syntese.yaml ]; then
     fail_step "Step 5: Config file not found"
 fi
 end_step "Step 5: Configuration validated"

--- a/tests/integration/run-test.sh
+++ b/tests/integration/run-test.sh
@@ -5,7 +5,7 @@ set -e
 
 cd "$(dirname "$0")"
 
-echo "🚀 Running Agent Orchestrator onboarding integration test..."
+echo "🚀 Running Syntese onboarding integration test..."
 echo ""
 
 # Build and run


### PR DESCRIPTION
## Summary
- rebrand scoped test fixtures, plugin/mobile/web strings, and dashboard titles from Agent Orchestrator to Syntese
- update config fixture names to syntese.yaml and mobile/openclaw notifier branding to Syntese
- keep the path assertions green during the split rollout by accepting both .agent-orchestrator and .syntese until the core path rename lands

## Testing
- pnpm run typecheck
- pnpm test
- pnpm run lint

Closes #50