### PR TITLE
feat: rename primary CLI command to syn

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Spawn parallel AI coding agents, each in its own git worktree. Agents autonomous
 
 Syntese manages fleets of AI coding agents working in parallel on your codebase. Each agent gets its own git worktree, its own branch, and its own PR. When CI fails, the agent fixes it. When reviewers leave comments, the agent addresses them. You only get pulled in when human judgment is needed.
 
-`ao` remains the backward-compatible CLI alias, so the commands below continue to use `ao`.
+Use `syn` as the primary CLI command. `syntese` and `ao` are also available as aliases.
 
 **Agent-agnostic** (Claude Code, Codex, Aider) · **Runtime-agnostic** (tmux, Docker) · **Tracker-agnostic** (GitHub, Linear)
 
@@ -54,38 +54,38 @@ git clone https://github.com/sigvardt/syntese.git
 cd syntese && bash scripts/setup.sh
 
 # One command to clone, configure, and launch
-ao start https://github.com/your-org/your-repo
+syn start https://github.com/your-org/your-repo
 ```
 
 Auto-detects language, package manager, SCM platform, and default branch. Generates `syntese.yaml` and starts the dashboard + orchestrator.
-On supported hosts, `ao start` also brings up the supervised dashboard services automatically. Use `ao services status --strict` to confirm dashboard and websocket readiness.
+On supported hosts, `syn start` also brings up the supervised dashboard services automatically. Use `syn services status --strict` to confirm dashboard and websocket readiness.
 
 **Option B — From an existing local repo:**
 
 ```bash
-cd ~/your-project && ao init --auto
-ao start
+cd ~/your-project && syn init --auto
+syn start
 ```
 
 Then spawn agents:
 
 ```bash
-ao spawn my-project 123    # GitHub issue, Linear ticket, or ad-hoc
+syn spawn my-project 123    # GitHub issue, Linear ticket, or ad-hoc
 ```
 
-Dashboard opens at `http://localhost:3000`. Run `ao status` for the CLI view.
+Dashboard opens at `http://localhost:3000`. Run `syn status` for the CLI view.
 
 For resilient dashboard + terminal websocket uptime (including XDA terminal connectivity), install supervised services:
 
 ```bash
-ao services install
-ao services status
+syn services install
+syn services status
 ```
 
 ## How It Works
 
 ```
-ao spawn my-project 123
+syn spawn my-project 123
 ```
 
 1. **Workspace** creates an isolated git worktree with a feature branch
@@ -166,19 +166,19 @@ See [`syntese.yaml.example`](syntese.yaml.example) for the full reference.
 ## CLI
 
 ```bash
-ao status                              # Overview of all sessions
-ao spawn <project> [issue]             # Spawn an agent
-ao send <session> "Fix the tests"      # Send instructions
-ao session ls                          # List sessions
-ao session kill <session>              # Kill a session
-ao session restore <session>           # Revive a crashed agent
-ao dashboard                           # Open web dashboard (dev mode)
-ao services install|start|stop|status  # Supervised dashboard/ws runtime
+syn status                              # Overview of all sessions
+syn spawn <project> [issue]             # Spawn an agent
+syn send <session> "Fix the tests"      # Send instructions
+syn session ls                          # List sessions
+syn session kill <session>              # Kill a session
+syn session restore <session>           # Revive a crashed agent
+syn dashboard                           # Open web dashboard (dev mode)
+syn services install|start|stop|status  # Supervised dashboard/ws runtime
 ```
 
 ## Supervised Runtime (Recommended)
 
-`ao services` runs and monitors all three runtime endpoints:
+`syn services` runs and monitors all three runtime endpoints:
 
 - dashboard web server (`3000`)
 - terminal websocket server (`14800`)
@@ -188,10 +188,10 @@ Use this for normal operation instead of ad-hoc `pnpm dev` shell processes:
 
 ```bash
 # One-time setup (installs systemd user services on Linux, fallback supervisor elsewhere)
-ao services install
+syn services install
 
 # Check readiness for dashboard + XDA websocket backends
-ao services status --strict
+syn services status --strict
 ```
 
 ## Why Syntese?
@@ -200,7 +200,7 @@ Running one AI agent in a terminal is easy. Running 30 across different issues, 
 
 **Without orchestration**, you manually: create branches, start agents, check if they're stuck, read CI failures, forward review comments, track which PRs are ready to merge, clean up when done.
 
-**With Syntese**, you: `ao spawn` and walk away. The system handles isolation, feedback routing, and status tracking. You review PRs and make decisions — the rest is automated.
+**With Syntese**, you: `syn spawn` and walk away. The system handles isolation, feedback routing, and status tracking. You review PRs and make decisions — the rest is automated.
 
 ## Prerequisites
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -91,12 +91,12 @@ npm install -g pnpm
 
 ## First-Time Configuration
 
-### Quick Onboarding with `ao start <url>`
+### Quick Onboarding with `syn start <url>`
 
 The fastest way to get started with any repo:
 
 ```bash
-ao start https://github.com/your-org/your-repo
+syn start https://github.com/your-org/your-repo
 ```
 
 This single command will:
@@ -109,43 +109,43 @@ This single command will:
 Supports GitHub, GitLab, and Bitbucket URLs (HTTPS and SSH):
 
 ```bash
-ao start https://github.com/owner/repo
-ao start https://gitlab.com/org/project
-ao start git@github.com:owner/repo.git
+syn start https://github.com/owner/repo
+syn start https://gitlab.com/org/project
+syn start git@github.com:owner/repo.git
 ```
 
 If the repo already has a `syntese.yaml`, it will be used as-is.
 
 ### Supervised Runtime (Recommended)
 
-Use `ao services` for resilient dashboard and terminal connectivity:
+Use `syn services` for resilient dashboard and terminal connectivity:
 
 ```bash
 # One-time install (systemd user services on Linux, portable supervisor fallback elsewhere)
-ao services install
+syn services install
 
 # Verify dashboard + websocket readiness (3000/14800/14801)
-ao services status --strict
+syn services status --strict
 ```
 
 This is the recommended migration path from ad-hoc `pnpm dev` shell processes.  
-`ao dashboard` remains available for local development but is intentionally unsupervised.
+`syn dashboard` remains available for local development but is intentionally unsupervised.
 
 ### Runtime Acceptance Checks (Issue #417)
 
-After `ao services install`, validate:
+After `syn services install`, validate:
 
 1. Killing any one of the three processes auto-recovers without manual restart.
 2. Dashboard endpoints remain reachable (`/ao/` and `/sessions/<id>` via your proxy/local routing).
 3. Terminal no longer stalls on `Connecting... XDA` due to missing ws backends (`14800`/`14801` healthy).
 
-### Quick Setup with `ao init`
+### Quick Setup with `syn init`
 
 For more control over configuration:
 
 ```bash
 cd ~/your-repo
-ao init
+syn init
 ```
 
 The wizard will prompt you for:
@@ -162,7 +162,7 @@ The wizard will prompt you for:
 10. **Local path** - Path to your repository
 11. **Default branch** - Main branch name (usually `main` or `master`)
 
-### What `ao init` Detects Automatically
+### What `syn init` Detects Automatically
 
 The wizard is smart and tries to help:
 
@@ -425,7 +425,7 @@ See [CLAUDE.md](./CLAUDE.md) for plugin development guidelines.
 
 ```bash
 # Run init wizard
-ao init
+syn init
 
 # Or copy an example
 cp examples/simple-github.yaml syntese.yaml
@@ -528,10 +528,10 @@ df -h
 
 ```bash
 # List active sessions
-ao session ls
+syn session ls
 
 # Check status dashboard
-ao status
+syn status
 ```
 
 ### "Agent not responding"
@@ -542,17 +542,17 @@ ao status
 
 ```bash
 # Check session status
-ao status
+syn status
 
 # Attach to session to investigate
-ao open <session-name>
+syn open <session-name>
 
 # Send message to agent
-ao send <session-name> "Please report your current status"
+syn send <session-name> "Please report your current status"
 
 # Kill and respawn if necessary
-ao session kill <session-name>
-ao spawn <project-id> <issue-id>
+syn session kill <session-name>
+syn spawn <project-id> <issue-id>
 ```
 
 ### "Permission denied" when spawning
@@ -782,25 +782,25 @@ projects:
 
 Three ways:
 
-1. **Dashboard** - `ao start` then visit http://localhost:3000 (or your configured `port:`)
-2. **CLI status** - `ao status` (text-based dashboard)
-3. **Attach to session** - `ao open <session-name>` (live terminal)
+1. **Dashboard** - `syn start` then visit http://localhost:3000 (or your configured `port:`)
+2. **CLI status** - `syn status` (text-based dashboard)
+3. **Attach to session** - `syn open <session-name>` (live terminal)
 
 ### What if an agent gets stuck?
 
 ```bash
 # Check status
-ao status
+syn status
 
 # Send message
-ao send <session-name> "What's your current status?"
+syn send <session-name> "What's your current status?"
 
 # Attach to investigate
-ao open <session-name>
+syn open <session-name>
 
 # Kill and respawn if necessary
-ao session kill <session-name>
-ao spawn <project-id> <issue-id>
+syn session kill <session-name>
+syn spawn <project-id> <issue-id>
 ```
 
 Agents also send "stuck" notifications automatically after inactivity threshold.
@@ -809,13 +809,13 @@ Agents also send "stuck" notifications automatically after inactivity threshold.
 
 ```bash
 # List all sessions
-ao session ls
+syn session ls
 
 # Kill specific session
-ao session kill <session-name>
+syn session kill <session-name>
 
 # Cleanup script (example)
-ao session ls --json | jq -r '.[] | select(.status == "merged") | .id' | xargs -I{} ao session kill {}
+syn session ls --json | jq -r '.[] | select(.status == "merged") | .id' | xargs -I{} syn session kill {}
 ```
 
 ### Can I run multiple orchestrators?
@@ -826,7 +826,7 @@ Yes! Each orchestrator instance should have:
 - Different dashboard port (`port`) — e.g., 3000 for project A, 3001 for project B
 - Different config file
 
-For supervised runtime (`ao services`), default websocket ports are stable (`14800` + `14801`) so XDA routing stays predictable. For multiple orchestrator instances, set `terminalPort` and `directTerminalPort` explicitly in each config.
+For supervised runtime (`syn services`), default websocket ports are stable (`14800` + `14801`) so XDA routing stays predictable. For multiple orchestrator instances, set `terminalPort` and `directTerminalPort` explicitly in each config.
 
 Useful for:
 
@@ -836,9 +836,9 @@ Useful for:
 
 ## Next Steps
 
-1. **Run `ao init`** - Create your first config
-2. **Spawn an agent** - `ao spawn my-app ISSUE-123`
-3. **Monitor progress** - `ao status` or dashboard
+1. **Run `syn init`** - Create your first config
+2. **Spawn an agent** - `syn spawn my-app ISSUE-123`
+3. **Monitor progress** - `syn status` or dashboard
 4. **Read [CLAUDE.md](./CLAUDE.md)** - Code conventions and architecture
 5. **Explore examples** - See [examples/](./examples/) for more configs
 6. **Join the community** - Report issues, share configs, contribute plugins

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -13,11 +13,11 @@
 
 ```bash
 # Check readiness for dashboard + websocket backends
-ao services status --strict
+syn services status --strict
 
 # Restart supervised services
-ao services stop
-ao services start
+syn services stop
+syn services start
 ```
 
 **Expected healthy state**:
@@ -26,7 +26,7 @@ ao services start
 - `http://127.0.0.1:14800/health` returns `200`
 - `http://127.0.0.1:14801/health` returns `200`
 
-**Prevention**: Use `ao services install` so services are supervised and auto-restarted.
+**Prevention**: Use `syn services install` so services are supervised and auto-restarted.
 
 ## DirectTerminal: posix_spawnp failed error
 
@@ -82,7 +82,7 @@ npx node-gyp rebuild
 
 **Symptom**: API returns 500 with "No syntese.yaml found"
 
-**Fix**: Ensure config exists in the directory where you run `ao start`, or symlink it:
+**Fix**: Ensure config exists in the directory where you run `syn start`, or symlink it:
 
 ```bash
 ln -s /path/to/syntese.yaml packages/web/syntese.yaml

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 This directory contains example configurations for common use cases.
 
-`ao` remains the backward-compatible CLI alias, so the examples below continue to use `ao`.
+Use `syn` as the primary CLI command. `syntese` and `ao` are also available as aliases.
 
 ## Quick Start
 
@@ -11,7 +11,7 @@ Copy an example and customize:
 ```bash
 cp examples/simple-github.yaml syntese.yaml
 nano syntese.yaml  # edit as needed
-ao spawn my-app ISSUE-123
+syn spawn my-app ISSUE-123
 ```
 
 ## Examples
@@ -108,8 +108,8 @@ Add these to your shell profile (`~/.zshrc` or `~/.bashrc`) to persist them.
 After copying an example:
 
 1. **Edit the config** - Update repo paths, team IDs, etc.
-2. **Validate** - Run `ao start` to check for config errors
-3. **Spawn an agent** - Try `ao spawn project-id ISSUE-123`
-4. **Monitor** - Use `ao status` or open the dashboard (default http://localhost:3000, configurable via `port:` in config)
+2. **Validate** - Run `syn start` to check for config errors
+3. **Spawn an agent** - Try `syn spawn project-id ISSUE-123`
+4. **Monitor** - Use `syn status` or open the dashboard (default http://localhost:3000, configurable via `port:` in config)
 
 See [SETUP.md](../SETUP.md) for detailed configuration reference and troubleshooting.

--- a/packages/cli/__tests__/program.test.ts
+++ b/packages/cli/__tests__/program.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { createProgram } from "../src/program.js";
+
+describe("createProgram", () => {
+  it("uses syn as the primary command name in help output", () => {
+    const program = createProgram();
+    const help = program.helpInformation();
+    const normalizedHelp = help.replace(/\s+/g, " ");
+
+    expect(program.name()).toBe("syn");
+    expect(help).toContain("Usage: syn");
+    expect(help).not.toContain("Usage: ao");
+    expect(normalizedHelp).toContain("`syntese` and `ao` are also available as aliases");
+  });
+});

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@syntese/cli",
   "version": "0.1.0",
-  "description": "CLI for syntese — the `ao` and `syntese` commands",
+  "description": "CLI for Syntese — `syn` with `syntese` and `ao` aliases",
   "license": "MIT",
   "type": "module",
   "bin": {
-    "ao": "dist/index.js",
-    "syntese": "dist/index.js"
+    "syn": "dist/index.js",
+    "syntese": "dist/index.js",
+    "ao": "dist/index.js"
   },
   "main": "dist/index.js",
   "files": [

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { existsSync } from "node:fs";
 import chalk from "chalk";
 import type { Command } from "commander";
-import { loadConfig } from "@syntese/core";
+import { loadConfig, PRIMARY_CLI_COMMAND } from "@syntese/core";
 import { findWebDir, buildDashboardEnv, waitForPortAndOpen } from "../lib/web-dir.js";
 import { cleanNextCache, findRunningDashboardPid, findProcessWebDir, waitForPortFree } from "../lib/dashboard-rebuild.js";
 
@@ -60,7 +60,11 @@ export function registerDashboard(program: Command): void {
 
       const webDir = localWebDir;
 
-      console.log(chalk.yellow("Running in dev mode (unsupervised). For resilient runtime use `ao services start`.\n"));
+      console.log(
+        chalk.yellow(
+          `Running in dev mode (unsupervised). For resilient runtime use \`${PRIMARY_CLI_COMMAND} services start\`.\n`,
+        ),
+      );
       console.log(chalk.bold(`Starting dashboard on http://localhost:${port}\n`));
 
       const env = await buildDashboardEnv(
@@ -111,7 +115,7 @@ export function registerDashboard(program: Command): void {
             console.error(
               chalk.yellow(
                 "\nThis looks like a stale build cache issue. Try:\n\n" +
-                  `  ${chalk.cyan("ao dashboard --rebuild")}\n`,
+                  `  ${chalk.cyan(`${PRIMARY_CLI_COMMAND} dashboard --rebuild`)}\n`,
               ),
             );
           }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -5,7 +5,7 @@ import { cwd } from "node:process";
 import { stringify as yamlStringify } from "yaml";
 import chalk from "chalk";
 import type { Command } from "commander";
-import { generateSessionPrefix } from "@syntese/core";
+import { generateSessionPrefix, PRIMARY_CLI_COMMAND } from "@syntese/core";
 import { git, gh, execSilent } from "../lib/shell.js";
 import { findFreePort, MAX_PORT_SCAN } from "../lib/web-dir.js";
 import {
@@ -160,7 +160,7 @@ export function registerInit(program: Command): void {
       // Validate --smart requires --auto
       if (opts.smart && !opts.auto) {
         console.error(chalk.red("Error: --smart requires --auto"));
-        console.log(chalk.dim("Use: ao init --auto --smart"));
+        console.log(chalk.dim(`Use: ${PRIMARY_CLI_COMMAND} init --auto --smart`));
         process.exit(1);
       }
 
@@ -370,11 +370,13 @@ export function registerInit(program: Command): void {
         console.log("  1. Review the config (optional):");
         console.log(chalk.cyan(`     nano ${outputPath}\n`));
         console.log("  2. Start orchestrator + dashboard:");
-        console.log(chalk.cyan("     ao start\n"));
+        console.log(chalk.cyan(`     ${PRIMARY_CLI_COMMAND} start\n`));
 
         if (projectId) {
           console.log("  3. Spawn agent sessions:");
-          console.log(chalk.cyan(`     ao spawn ${projectId} ISSUE-123\n`));
+          console.log(
+            chalk.cyan(`     ${PRIMARY_CLI_COMMAND} spawn ${projectId} ISSUE-123\n`),
+          );
         } else {
           console.log("  3. Add a project to the config:");
           console.log(chalk.cyan(`     nano ${outputPath}\n`));
@@ -458,7 +460,11 @@ async function handleAutoMode(outputPath: string, smart: boolean): Promise<void>
         `  ⚠ No free port found in range ${DEFAULT_PORT}–${DEFAULT_PORT + MAX_PORT_SCAN - 1}.`,
       ),
     );
-    console.log(chalk.dim("    Set the port manually in the config before running ao start.\n"));
+    console.log(
+      chalk.dim(
+        `    Set the port manually in the config before running ${PRIMARY_CLI_COMMAND} start.\n`,
+      ),
+    );
   } else if (port !== DEFAULT_PORT) {
     console.log(chalk.yellow(`  ⚠ Port ${DEFAULT_PORT} is busy — using ${port} instead.`));
   }
@@ -514,16 +520,16 @@ async function handleAutoMode(outputPath: string, smart: boolean): Promise<void>
     console.log("  1. Edit config and update 'repo' field:");
     console.log(chalk.cyan(`     nano ${outputPath}\n`));
     console.log("  2. Start orchestrator + dashboard:");
-    console.log(chalk.cyan("     ao start\n"));
+    console.log(chalk.cyan(`     ${PRIMARY_CLI_COMMAND} start\n`));
     console.log("  3. Spawn agent sessions:");
-    console.log(chalk.cyan(`     ao spawn ${projectId} ISSUE-123\n`));
+    console.log(chalk.cyan(`     ${PRIMARY_CLI_COMMAND} spawn ${projectId} ISSUE-123\n`));
   } else {
     console.log("  1. Review the config (optional):");
     console.log(chalk.cyan(`     nano ${outputPath}\n`));
     console.log("  2. Start orchestrator + dashboard:");
-    console.log(chalk.cyan("     ao start\n"));
+    console.log(chalk.cyan(`     ${PRIMARY_CLI_COMMAND} start\n`));
     console.log("  3. Spawn agent sessions:");
-    console.log(chalk.cyan(`     ao spawn ${projectId} ISSUE-123\n`));
+    console.log(chalk.cyan(`     ${PRIMARY_CLI_COMMAND} spawn ${projectId} ISSUE-123\n`));
   }
 
   // Show warnings

--- a/packages/cli/src/commands/services.ts
+++ b/packages/cli/src/commands/services.ts
@@ -39,7 +39,7 @@ function colorProcessState(state: string): string {
 }
 
 function printServicesStatus(status: ManagedServicesStatus): void {
-  console.log(chalk.bold("\nAO Services\n"));
+  console.log(chalk.bold("\nSyntese Services\n"));
   const managerState = status.managerRunning ? chalk.green("running") : chalk.red("not running");
   console.log(`  Manager: ${chalk.cyan(status.manager)} (${managerState})`);
   console.log(`  Detail:  ${chalk.dim(status.managerDetail)}\n`);
@@ -204,7 +204,7 @@ export function registerServices(program: Command): void {
 
   services
     .command("run-supervisor")
-    .description("Internal: run portable AO services supervisor")
+    .description("Internal: run portable Syntese services supervisor")
     .action(async () => {
       try {
         const config = loadConfig();

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -229,7 +229,7 @@ export function registerSession(program: Command): void {
         if (!resolvedSession) {
           console.error(
             chalk.red(
-              "No session provided. Pass a session name or run this inside a managed AO session.",
+              "No session provided. Pass a session name or run this inside a managed Syntese session.",
             ),
           );
           process.exit(1);
@@ -300,7 +300,7 @@ export function registerSession(program: Command): void {
 
   session
     .command("remap")
-    .description("Re-discover and persist OpenCode session mapping for an AO session")
+    .description("Re-discover and persist OpenCode session mapping for a Syntese session")
     .argument("<session>", "Session name to remap")
     .option("-f, --force", "Force fresh remap by re-discovering the OpenCode session")
     .action(async (sessionName: string, opts: { force?: boolean }) => {

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -11,6 +11,7 @@ import {
   type OrchestratorConfig,
   type DecomposerConfig,
   DEFAULT_DECOMPOSER_CONFIG,
+  PRIMARY_CLI_COMMAND,
 } from "@syntese/core";
 import { exec } from "../lib/shell.js";
 import { banner } from "../lib/format.js";
@@ -154,7 +155,11 @@ export function registerSpawn(program: Command): void {
         }
 
         if (!opts.claimPr && opts.assignOnGithub) {
-          console.error(chalk.red("--assign-on-github requires --claim-pr on `ao spawn`."));
+          console.error(
+            chalk.red(
+              `--assign-on-github requires --claim-pr on \`${PRIMARY_CLI_COMMAND} spawn\`.`,
+            ),
+          );
           process.exit(1);
         }
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -24,6 +24,7 @@ import {
   generateConfigFromUrl,
   configToYaml,
   normalizeOrchestratorSessionStrategy,
+  PRIMARY_CLI_COMMAND,
   type OrchestratorConfig,
   type ProjectConfig,
   type ParsedRepoUrl,
@@ -88,7 +89,7 @@ function resolveProject(
 
   // Multiple projects, no argument — error
   throw new Error(
-    `Multiple projects configured. Specify which one to start:\n  ${projectIds.map((id) => `ao start ${id}`).join("\n  ")}`,
+    `Multiple projects configured. Specify which one to start:\n  ${projectIds.map((id) => `${PRIMARY_CLI_COMMAND} start ${id}`).join("\n  ")}`,
   );
 }
 
@@ -415,7 +416,7 @@ export function registerStart(program: Command): void {
           if (err instanceof Error) {
             if (err.message.includes("No syntese.yaml found")) {
               console.error(chalk.red("\nNo config found. Run:"));
-              console.error(chalk.cyan("  ao init\n"));
+              console.error(chalk.cyan(`  ${PRIMARY_CLI_COMMAND} init\n`));
             } else {
               console.error(chalk.red("\nError:"), err.message);
             }

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -11,6 +11,7 @@ import {
   type Tracker,
   type ProjectConfig,
   loadConfig,
+  PRIMARY_CLI_COMMAND,
 } from "@syntese/core";
 import { git, getTmuxSessions, getTmuxActivity } from "../lib/shell.js";
 import {
@@ -199,7 +200,7 @@ export function registerStatus(program: Command): void {
       try {
         config = loadConfig();
       } catch {
-        console.log(chalk.yellow("No config found. Run `ao init` first."));
+        console.log(chalk.yellow(`No config found. Run \`${PRIMARY_CLI_COMMAND} init\` first.`));
         console.log(chalk.dim("Falling back to session discovery...\n"));
         await showFallbackStatus();
         return;
@@ -315,7 +316,7 @@ export function registerStatus(program: Command): void {
           if (unverifiedTotal > 0) {
             console.log(
               chalk.yellow(
-                `  ⚠ ${unverifiedTotal} issue${unverifiedTotal !== 1 ? "s" : ""} awaiting verification (use \`ao verify --list\` to see them)`,
+                `  ⚠ ${unverifiedTotal} issue${unverifiedTotal !== 1 ? "s" : ""} awaiting verification (use \`${PRIMARY_CLI_COMMAND} verify --list\` to see them)`,
               ),
             );
           }

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -6,6 +6,7 @@ import {
   type OrchestratorConfig,
   type PluginRegistry,
   loadConfig,
+  PRIMARY_CLI_COMMAND,
 } from "@syntese/core";
 
 /**
@@ -28,7 +29,7 @@ function resolveProject(
 
   const ids = Object.keys(config.projects);
   if (ids.length === 0) {
-    console.error(chalk.red("No projects configured. Run `ao init` first."));
+    console.error(chalk.red(`No projects configured. Run \`${PRIMARY_CLI_COMMAND} init\` first.`));
     process.exit(1);
   }
   if (ids.length > 1) {
@@ -86,7 +87,7 @@ export function registerVerify(program: Command): void {
         try {
           config = loadConfig();
         } catch {
-          console.error(chalk.red("No config found. Run `ao init` first."));
+          console.error(chalk.red(`No config found. Run \`${PRIMARY_CLI_COMMAND} init\` first.`));
           process.exit(1);
           return;
         }
@@ -129,7 +130,11 @@ export function registerVerify(program: Command): void {
 
         // Verify/fail mode: requires an issue argument
         if (!issue) {
-          console.error(chalk.red("Issue number is required. Usage: ao verify <issue>"));
+          console.error(
+            chalk.red(
+              `Issue number is required. Usage: ${PRIMARY_CLI_COMMAND} verify <issue>`,
+            ),
+          );
           process.exit(1);
         }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,42 +1,5 @@
 #!/usr/bin/env node
 
-import { basename } from "node:path";
-import { Command } from "commander";
-import { registerInit } from "./commands/init.js";
-import { registerStatus } from "./commands/status.js";
-import { registerSpawn, registerBatchSpawn } from "./commands/spawn.js";
-import { registerSession } from "./commands/session.js";
-import { registerSend } from "./commands/send.js";
-import { registerReviewCheck } from "./commands/review-check.js";
-import { registerDashboard } from "./commands/dashboard.js";
-import { registerOpen } from "./commands/open.js";
-import { registerStart, registerStop } from "./commands/start.js";
-import { registerLifecycleWorker } from "./commands/lifecycle-worker.js";
-import { registerServices } from "./commands/services.js";
-import { registerVerify } from "./commands/verify.js";
+import { createProgram } from "./program.js";
 
-const program = new Command();
-const invokedName = basename(process.argv[1] ?? "");
-const commandName = invokedName === "syntese" ? "syntese" : "ao";
-
-program
-  .name(commandName)
-  .description("Syntese — manage parallel AI coding agents (`ao` is still supported)")
-  .version("0.1.0");
-
-registerInit(program);
-registerStart(program);
-registerStop(program);
-registerStatus(program);
-registerSpawn(program);
-registerBatchSpawn(program);
-registerSession(program);
-registerSend(program);
-registerReviewCheck(program);
-registerDashboard(program);
-registerServices(program);
-registerOpen(program);
-registerLifecycleWorker(program);
-registerVerify(program);
-
-program.parse();
+createProgram().parse();

--- a/packages/cli/src/lib/lifecycle-service.ts
+++ b/packages/cli/src/lib/lifecycle-service.ts
@@ -9,7 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
-import { getProjectBaseDir, type OrchestratorConfig } from "@syntese/core";
+import { PRIMARY_CLI_COMMAND, getProjectBaseDir, type OrchestratorConfig } from "@syntese/core";
 
 const LIFECYCLE_PID_FILE = "lifecycle-worker.pid";
 const LIFECYCLE_LOG_FILE = "lifecycle-worker.log";
@@ -142,7 +142,7 @@ function resolveLifecycleWorkerLaunch(projectId: string): { command: string; arg
   }
 
   return {
-    command: "ao",
+    command: PRIMARY_CLI_COMMAND,
     args: workerArgs,
   };
 }

--- a/packages/cli/src/lib/services.ts
+++ b/packages/cli/src/lib/services.ts
@@ -11,7 +11,12 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { generateConfigHash, getDataRootDir, type OrchestratorConfig } from "@syntese/core";
+import {
+  PRIMARY_CLI_COMMAND,
+  generateConfigHash,
+  getDataRootDir,
+  type OrchestratorConfig,
+} from "@syntese/core";
 import { exec, execSilent } from "./shell.js";
 import { findWebDir, isPortAvailable } from "./web-dir.js";
 
@@ -228,10 +233,10 @@ function buildSystemdUnitContent(
   const { ports, webDir, config } = context;
   const serviceName =
     id === "dashboard"
-      ? "AO Dashboard"
+      ? "Syntese Dashboard"
       : id === "terminal-ws"
-        ? "AO Terminal WebSocket"
-        : "AO Direct Terminal WebSocket";
+        ? "Syntese Terminal WebSocket"
+        : "Syntese Direct Terminal WebSocket";
 
   const env: Array<[string, string]> = [
     ["AO_CONFIG_PATH", config.configPath],
@@ -455,7 +460,7 @@ function resolveSupervisorLaunch(): { command: string; args: string[] } {
   }
 
   return {
-    command: "ao",
+    command: PRIMARY_CLI_COMMAND,
     args: supervisorArgs,
   };
 }
@@ -629,10 +634,10 @@ export async function installManagedServices(
   const context = await getServiceContext(config);
 
   if (manager === "systemd") {
-    const { units, unitDir } = await writeSystemdUnits(context, { enable: opts?.enable });
+    const { unitDir } = await writeSystemdUnits(context, { enable: opts?.enable });
     return {
       manager,
-      detail: `installed units in ${unitDir} (${units.dashboard}, ${units.terminalWs}, ${units.directTerminalWs})`,
+      detail: `installed systemd user services in ${unitDir}`,
     };
   }
 
@@ -651,7 +656,7 @@ async function getSystemdStatus(context: ServiceContext): Promise<ManagedService
   return {
     manager: "systemd",
     managerRunning,
-    managerDetail: `${units.dashboard}, ${units.terminalWs}, ${units.directTerminalWs}`,
+    managerDetail: "systemd user services",
     processStates,
     services,
     allReady,
@@ -854,7 +859,7 @@ export async function runSupervisorLoop(config: OrchestratorConfig): Promise<voi
     const retries = (restartCounters.get(spec.id) ?? 0) + 1;
     restartCounters.set(spec.id, retries);
     const delayMs = Math.min(15_000, 500 * 2 ** Math.min(retries, 5));
-    console.error(`[ao-services] ${spec.id} ${reason}; restarting in ${delayMs}ms`);
+    console.error(`[syn-services] ${spec.id} ${reason}; restarting in ${delayMs}ms`);
     const timer = setTimeout(() => {
       if (!shuttingDown) {
         startSpec(spec);
@@ -901,7 +906,7 @@ export async function runSupervisorLoop(config: OrchestratorConfig): Promise<voi
   const handleShutdown = (signal: string) => {
     if (shuttingDown) return;
     shuttingDown = true;
-    console.log(`[ao-services] received ${signal}; shutting down managed services`);
+    console.log(`[syn-services] received ${signal}; shutting down managed services`);
     for (const [, child] of children) {
       try {
         child.kill("SIGTERM");

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,0 +1,41 @@
+import { CLI_ALIASES, PRIMARY_CLI_COMMAND } from "@syntese/core";
+import { Command } from "commander";
+import { registerInit } from "./commands/init.js";
+import { registerStatus } from "./commands/status.js";
+import { registerSpawn, registerBatchSpawn } from "./commands/spawn.js";
+import { registerSession } from "./commands/session.js";
+import { registerSend } from "./commands/send.js";
+import { registerReviewCheck } from "./commands/review-check.js";
+import { registerDashboard } from "./commands/dashboard.js";
+import { registerOpen } from "./commands/open.js";
+import { registerStart, registerStop } from "./commands/start.js";
+import { registerLifecycleWorker } from "./commands/lifecycle-worker.js";
+import { registerServices } from "./commands/services.js";
+import { registerVerify } from "./commands/verify.js";
+
+export function createProgram(): Command {
+  const program = new Command();
+  const aliases = CLI_ALIASES.map((alias) => `\`${alias}\``).join(" and ");
+
+  program
+    .name(PRIMARY_CLI_COMMAND)
+    .description(`Syntese — manage parallel AI coding agents (${aliases} are also available as aliases)`)
+    .version("0.1.0");
+
+  registerInit(program);
+  registerStart(program);
+  registerStop(program);
+  registerStatus(program);
+  registerSpawn(program);
+  registerBatchSpawn(program);
+  registerSession(program);
+  registerSend(program);
+  registerReviewCheck(program);
+  registerDashboard(program);
+  registerServices(program);
+  registerOpen(program);
+  registerLifecycleWorker(program);
+  registerVerify(program);
+
+  return program;
+}

--- a/packages/core/src/__tests__/prompt-builder.test.ts
+++ b/packages/core/src/__tests__/prompt-builder.test.ts
@@ -214,6 +214,6 @@ describe("BASE_AGENT_PROMPT", () => {
     expect(BASE_AGENT_PROMPT).toContain("Session Lifecycle");
     expect(BASE_AGENT_PROMPT).toContain("Git Workflow");
     expect(BASE_AGENT_PROMPT).toContain("PR Best Practices");
-    expect(BASE_AGENT_PROMPT).toContain("ao session claim-pr");
+    expect(BASE_AGENT_PROMPT).toContain("syn session claim-pr");
   });
 });

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -1017,7 +1017,7 @@ describe("spawn", () => {
 
     expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({ id: expect.any(String) }),
-      expect.stringContaining("ao session claim-pr"),
+      expect.stringContaining("syn session claim-pr"),
     );
     vi.useRealTimers();
   });

--- a/packages/core/src/cli-command.ts
+++ b/packages/core/src/cli-command.ts
@@ -1,0 +1,2 @@
+export const PRIMARY_CLI_COMMAND = "syn";
+export const CLI_ALIASES = ["syntese", "ao"] as const;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -16,6 +16,7 @@ import { resolve, join, basename } from "node:path";
 import { homedir } from "node:os";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
+import { PRIMARY_CLI_COMMAND } from "./cli-command.js";
 import type { OrchestratorConfig } from "./types.js";
 import { generateSessionPrefix } from "./paths.js";
 
@@ -36,7 +37,7 @@ const HOME_CONFIG_PATHS = [
 ];
 
 const MISSING_CONFIG_ERROR =
-  "No syntese.yaml found (legacy agent-orchestrator.yaml is also supported). Run `ao init` to create one.";
+  `No syntese.yaml found (legacy agent-orchestrator.yaml is also supported). Run \`${PRIMARY_CLI_COMMAND} init\` to create one.`;
 
 function inferScmPlugin(project: {
   repo: string;

--- a/packages/core/src/feedback-tools.ts
+++ b/packages/core/src/feedback-tools.ts
@@ -43,12 +43,12 @@ export interface FeedbackToolContract {
 export const FEEDBACK_TOOL_CONTRACTS: Record<FeedbackToolName, FeedbackToolContract> = {
   bug_report: {
     name: FEEDBACK_TOOL_NAMES.BUG_REPORT,
-    description: "Capture reproducible bugs found while working in AO sessions.",
+    description: "Capture reproducible bugs found while working in Syntese sessions.",
     schema: BugReportSchema,
   },
   improvement_suggestion: {
     name: FEEDBACK_TOOL_NAMES.IMPROVEMENT_SUGGESTION,
-    description: "Capture actionable improvement suggestions discovered in AO sessions.",
+    description: "Capture actionable improvement suggestions discovered in Syntese sessions.",
     schema: ImprovementSuggestionSchema,
   },
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,6 +71,7 @@ export type { VerificationEvaluation, VerificationExecution } from "./verificati
 // Prompt builder — layered prompt composition
 export { buildPrompt, BASE_AGENT_PROMPT } from "./prompt-builder.js";
 export type { PromptBuildConfig } from "./prompt-builder.js";
+export { PRIMARY_CLI_COMMAND, CLI_ALIASES } from "./cli-command.js";
 
 // Decomposer — LLM-driven task decomposition
 export {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1043,7 +1043,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       .trim();
 
     const lines = [
-      "You are taking over an orphaned PR because the previous AO session exited unexpectedly.",
+      "You are taking over an orphaned PR because the previous Syntese session exited unexpectedly.",
       `Previous session: ${session.id}`,
       `Recovery attempt: ${recoveryAttempt}`,
       `Trigger: ${action.trigger}`,

--- a/packages/core/src/orchestrator-prompt.ts
+++ b/packages/core/src/orchestrator-prompt.ts
@@ -1,10 +1,11 @@
 /**
  * Orchestrator Prompt Generator — generates orchestrator prompt content.
  *
- * This is injected via `ao start` to provide orchestrator-specific context
+ * This is injected via `syn start` to provide orchestrator-specific context
  * when the orchestrator agent runs.
  */
 
+import { PRIMARY_CLI_COMMAND } from "./cli-command.js";
 import type { OrchestratorConfig, ProjectConfig } from "./types.js";
 
 export interface OrchestratorPromptConfig {
@@ -20,6 +21,7 @@ export interface OrchestratorPromptConfig {
  */
 export function generateOrchestratorPrompt(opts: OrchestratorPromptConfig): string {
   const { config, projectId, project } = opts;
+  const cli = PRIMARY_CLI_COMMAND;
   const sections: string[] = [];
 
   // Header
@@ -44,27 +46,27 @@ Your role is to coordinate and manage worker agent sessions. You do NOT write co
 
 \`\`\`bash
 # See all sessions at a glance
-ao status
+${cli} status
 
 # Spawn sessions for issues (GitHub: #123, Linear: INT-1234, etc.)
-ao spawn ${projectId} INT-1234
-ao spawn ${projectId} --claim-pr 123
-ao batch-spawn ${projectId} INT-1 INT-2 INT-3
+${cli} spawn ${projectId} INT-1234
+${cli} spawn ${projectId} --claim-pr 123
+${cli} batch-spawn ${projectId} INT-1 INT-2 INT-3
 
 # List sessions
-ao session ls -p ${projectId}
+${cli} session ls -p ${projectId}
 
 # Send message to a session
-ao send ${project.sessionPrefix}-1 "Your message here"
+${cli} send ${project.sessionPrefix}-1 "Your message here"
 
 # Claim an existing PR for a session
-ao session claim-pr 123 ${project.sessionPrefix}-1
+${cli} session claim-pr 123 ${project.sessionPrefix}-1
 
 # Kill a session
-ao session kill ${project.sessionPrefix}-1
+${cli} session kill ${project.sessionPrefix}-1
 
 # Open all sessions in terminal tabs
-ao open ${projectId}
+${cli} open ${projectId}
 \`\`\``);
 
   // Available Commands
@@ -72,17 +74,17 @@ ao open ${projectId}
 
 | Command | Description |
 |---------|-------------|
-| \`ao status\` | Show all sessions with PR/CI/review status |
-| \`ao spawn <project> [issue] [--claim-pr <pr>]\` | Spawn a worker session, optionally attached to an existing PR |
-| \`ao batch-spawn <project> <issues...>\` | Spawn multiple sessions in parallel |
-| \`ao session ls [-p project]\` | List all sessions (optionally filter by project) |
-| \`ao session claim-pr <pr> [session]\` | Attach an existing PR to a session |
-| \`ao session attach <session>\` | Attach to a session's tmux window |
-| \`ao session kill <session>\` | Kill a specific session |
-| \`ao session cleanup [-p project]\` | Kill completed/merged sessions |
-| \`ao send <session> <message>\` | Send a message to a running session |
-| \`ao dashboard\` | Start the web dashboard (http://localhost:${config.port ?? 3000}) |
-| \`ao open <project>\` | Open all project sessions in terminal tabs |`);
+| \`${cli} status\` | Show all sessions with PR/CI/review status |
+| \`${cli} spawn <project> [issue] [--claim-pr <pr>]\` | Spawn a worker session, optionally attached to an existing PR |
+| \`${cli} batch-spawn <project> <issues...>\` | Spawn multiple sessions in parallel |
+| \`${cli} session ls [-p project]\` | List all sessions (optionally filter by project) |
+| \`${cli} session claim-pr <pr> [session]\` | Attach an existing PR to a session |
+| \`${cli} session attach <session>\` | Attach to a session's tmux window |
+| \`${cli} session kill <session>\` | Kill a specific session |
+| \`${cli} session cleanup [-p project]\` | Kill completed/merged sessions |
+| \`${cli} send <session> <message>\` | Send a message to a running session |
+| \`${cli} dashboard\` | Start the web dashboard (http://localhost:${config.port ?? 3000}) |
+| \`${cli} open <project>\` | Open all project sessions in terminal tabs |`);
 
   // Session Management
   sections.push(`## Session Management
@@ -98,7 +100,7 @@ When you spawn a session:
 
 ### Monitoring Progress
 
-Use \`ao status\` to see:
+Use \`${cli} status\` to see:
 - Current session status (working, pr_open, review_pending, etc.)
 - PR state (open/merged/closed)
 - CI status (passing/failing/pending)
@@ -109,25 +111,25 @@ Use \`ao status\` to see:
 
 Send instructions to a running agent:
 \`\`\`bash
-ao send ${project.sessionPrefix}-1 "Please address the review comments on your PR"
+${cli} send ${project.sessionPrefix}-1 "Please address the review comments on your PR"
 \`\`\`
 
 ### PR Takeover
 
 If a session needs to continue work on an existing PR:
 \`\`\`bash
-ao session claim-pr 123 ${project.sessionPrefix}-1
+${cli} session claim-pr 123 ${project.sessionPrefix}-1
 # or do it at spawn time
-ao spawn ${projectId} --claim-pr 123
+${cli} spawn ${projectId} --claim-pr 123
 \`\`\`
 
-This updates AO metadata, switches the worktree onto the PR branch, and lets lifecycle reactions keep routing CI and review feedback to that session.
+This updates Syntese metadata, switches the worktree onto the PR branch, and lets lifecycle reactions keep routing CI and review feedback to that session.
 
 ### Cleanup
 
 Remove completed sessions:
 \`\`\`bash
-ao session cleanup -p ${projectId}  # Kill sessions where PR is merged or issue is closed
+${cli} session cleanup -p ${projectId}  # Kill sessions where PR is merged or issue is closed
 \`\`\``);
 
   // Dashboard
@@ -171,15 +173,15 @@ ${reactionLines.join("\n")}`);
 
 ### Bulk Issue Processing
 1. Get list of issues from tracker (GitHub/Linear/etc.)
-2. Use \`ao batch-spawn\` to spawn sessions for each issue
-3. Monitor with \`ao status\` or the dashboard
+2. Use \`${cli} batch-spawn\` to spawn sessions for each issue
+3. Monitor with \`${cli} status\` or the dashboard
 4. Agents will fetch, implement, test, PR, and respond to reviews
-5. Use \`ao session cleanup\` when PRs are merged
+5. Use \`${cli} session cleanup\` when PRs are merged
 
 ### Handling Stuck Agents
-1. Check \`ao status\` for sessions in "stuck" or "needs_input" state
-2. Attach with \`ao session attach <session>\` to see what they're doing
-3. Send clarification or instructions with \`ao send <session> '...'\`
+1. Check \`${cli} status\` for sessions in "stuck" or "needs_input" state
+2. Attach with \`${cli} session attach <session>\` to see what they're doing
+3. Send clarification or instructions with \`${cli} send <session> '...'\`
 4. Or kill and respawn with fresh context if needed
 
 ### PR Review Flow
@@ -192,9 +194,9 @@ ${reactionLines.join("\n")}`);
 ### Manual Intervention
 When an agent needs human judgment:
 1. You'll get a notification (desktop/slack/webhook)
-2. Check the dashboard or \`ao status\` for details
-3. Attach to the session if needed: \`ao session attach <session>\`
-4. Send instructions: \`ao send <session> '...'\`
+2. Check the dashboard or \`${cli} status\` for details
+3. Attach to the session if needed: \`${cli} session attach <session>\`
+4. Send instructions: \`${cli} send <session> '...'\`
 5. Or handle it yourself (merge PR, close issue, etc.)`);
 
   // Tips
@@ -210,7 +212,7 @@ When an agent needs human judgment:
 
 5. **Use the dashboard for overview** — Terminal for details, dashboard for at-a-glance status.
 
-6. **Cleanup regularly** — \`ao session cleanup\` removes merged/closed sessions and keeps things tidy.
+6. **Cleanup regularly** — \`${cli} session cleanup\` removes merged/closed sessions and keeps things tidy.
 
 7. **Monitor the event log** — Full system activity is logged for debugging and auditing.
 

--- a/packages/core/src/prompt-builder.ts
+++ b/packages/core/src/prompt-builder.ts
@@ -12,18 +12,19 @@
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { PRIMARY_CLI_COMMAND } from "./cli-command.js";
 import type { ProjectConfig } from "./types.js";
 
 // =============================================================================
 // LAYER 1: BASE AGENT PROMPT
 // =============================================================================
 
-export const BASE_AGENT_PROMPT = `You are an AI coding agent managed by Syntese (ao).
+export const BASE_AGENT_PROMPT = `You are an AI coding agent managed by Syntese (${PRIMARY_CLI_COMMAND}).
 
 ## Session Lifecycle
 - You are running inside a managed session. Focus on the assigned task.
 - When you finish your work, create a PR and push it. The orchestrator will handle CI monitoring and review routing.
-- If you're told to take over or continue work on an existing PR, run \`ao session claim-pr <pr-number-or-url>\` from inside this session before making changes.
+- If you're told to take over or continue work on an existing PR, run \`${PRIMARY_CLI_COMMAND} session claim-pr <pr-number-or-url>\` from inside this session before making changes.
 - If CI fails, the orchestrator will send you the failures — fix them and push again.
 - If reviewers request changes, the orchestrator will forward their comments — address each one, push fixes, and reply to the comments.
 

--- a/packages/syntese/package.json
+++ b/packages/syntese/package.json
@@ -5,8 +5,9 @@
   "license": "MIT",
   "type": "module",
   "bin": {
-    "ao": "bin/ao.js",
-    "syntese": "bin/ao.js"
+    "syn": "bin/ao.js",
+    "syntese": "bin/ao.js",
+    "ao": "bin/ao.js"
   },
   "files": [
     "bin"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -140,14 +140,25 @@ cd packages/cli
 npm link
 cd "$REPO_ROOT"
 
-# ─── Verify ao is in PATH ────────────────────────────────────────────────────
+# ─── Verify syn + aliases are in PATH ────────────────────────────────────────
 
 echo ""
-if command -v ao &> /dev/null; then
-  echo "[ok] 'ao' command is available in PATH"
-else
+MISSING_COMMANDS=()
+for cmd in syn syntese ao; do
+  if command -v "$cmd" &> /dev/null; then
+    echo "[ok] '$cmd' command is available in PATH"
+    "$cmd" --version >/dev/null 2>&1 || {
+      echo "WARNING: '$cmd' is in PATH but failed to run."
+      MISSING_COMMANDS+=("$cmd")
+    }
+  else
+    MISSING_COMMANDS+=("$cmd")
+  fi
+done
+
+if [ ${#MISSING_COMMANDS[@]} -gt 0 ]; then
   NPM_BIN="$(npm bin -g 2>/dev/null || npm config get prefix)/bin"
-  echo "WARNING: 'ao' is not in your PATH."
+  echo "WARNING: Missing or broken CLI commands: ${MISSING_COMMANDS[*]}"
   echo "  Add this to your shell profile (~/.zshrc or ~/.bashrc):"
   echo ""
   echo "    export PATH=\"$NPM_BIN:\$PATH\""
@@ -160,8 +171,11 @@ fi
 echo ""
 echo "Setup complete!"
 echo ""
+echo "Primary CLI: syn"
+echo "Aliases: syntese, ao"
+echo ""
 echo "Next steps:"
 echo "  1. cd /path/to/your-project"
-echo "  2. ao init --auto"
-echo "  3. ao start"
+echo "  2. syn init --auto"
+echo "  3. syn start"
 echo ""

--- a/tests/integration/onboarding-test.sh
+++ b/tests/integration/onboarding-test.sh
@@ -49,13 +49,15 @@ if ! ./scripts/setup.sh; then
 fi
 end_step "Step 2: Setup completed"
 
-# Step 3: Verify ao command is available
-start_step "Step 3: Verify ao command"
-if ! command -v ao &> /dev/null; then
-    fail_step "Step 3: ao command not found (npm link failed?)"
-fi
-ao --version || fail_step "Step 3: ao --version failed"
-end_step "Step 3: ao command available"
+# Step 3: Verify syn and aliases are available
+start_step "Step 3: Verify syn and aliases"
+for cmd in syn syntese ao; do
+    if ! command -v "$cmd" &> /dev/null; then
+        fail_step "Step 3: $cmd command not found (npm link failed?)"
+    fi
+    "$cmd" --version || fail_step "Step 3: $cmd --version failed"
+done
+end_step "Step 3: syn, syntese, and ao commands available"
 
 # Step 4: Create minimal test config
 start_step "Step 4: Create test configuration"
@@ -81,7 +83,7 @@ end_step "Step 4: Configuration created"
 
 # Step 5: Verify config is valid
 start_step "Step 5: Validate configuration"
-# ao init would fail if run again, so we just verify the file is readable
+# syn init would fail if run again, so we just verify the file is readable
 if [ ! -f syntese.yaml ]; then
     fail_step "Step 5: Config file not found"
 fi
@@ -90,7 +92,7 @@ end_step "Step 5: Configuration validated"
 # Step 6: Start Syntese (in background)
 start_step "Step 6: Start Syntese"
 # Start in background and capture PID
-ao start --no-orchestrator &  # Only start the dashboard, not the Syntese session
+syn start --no-orchestrator &  # Only start the dashboard, not the Syntese session
 DASHBOARD_PID=$!
 
 # Wait for dashboard to be ready (max 30 seconds)
@@ -141,7 +143,7 @@ for i in $(seq 1 $max_retries); do
         break
     fi
     if [ $i -eq $max_retries ]; then
-        fail_step "Step 8: WebSocket terminal server not responding (bug: ao start didn't launch all services)"
+        fail_step "Step 8: WebSocket terminal server not responding (bug: syn start didn't launch all services)"
     fi
     sleep 1
 done


### PR DESCRIPTION
Summary
- make syn the primary CLI name while keeping syntese and ao as aliases
- update CLI help, setup/onboarding flows, and orchestrator/agent prompt text to prefer syn
- refresh docs and add CLI coverage for the new primary command name

Testing
- pnpm run typecheck
- pnpm test
- pnpm run lint

Closes #68