### PR TITLE
feat: per-account capacity tracking with syn capacity command

### DIFF
--- a/packages/cli/__tests__/lib/capacity-store.test.ts
+++ b/packages/cli/__tests__/lib/capacity-store.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  computeAccountCapacity,
+  getEffectiveAccounts,
+  resolveAccountForProject,
+  type AccountCapacityState,
+} from "../../src/lib/capacity-store.js";
+import type { AccountConfig, OrchestratorConfig } from "@syntese/core";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeState(overrides: Partial<AccountCapacityState> = {}): AccountCapacityState {
+  return {
+    version: 1,
+    accountId: "test-account",
+    consumed: 0,
+    windowStartedAt: null,
+    overageConsumed: 0,
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<AccountConfig> = {}): AccountConfig {
+  return {
+    agent: "codex",
+    model: "gpt-5.4-xhigh",
+    baseQuota: { estimatedTotal: 100, windowHours: 5 },
+    ...overrides,
+  };
+}
+
+function makeOrchestratorConfig(
+  overrides: Partial<OrchestratorConfig> = {},
+): OrchestratorConfig {
+  return {
+    configPath: "/tmp/syntese.yaml",
+    port: 3000,
+    readyThresholdMs: 300_000,
+    defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+    projects: {
+      "my-app": {
+        name: "My App",
+        repo: "org/my-app",
+        path: "/tmp/my-app",
+        defaultBranch: "main",
+        sessionPrefix: "app",
+        agentConfig: {},
+      },
+    },
+    notifiers: {},
+    notificationRouting: { urgent: [], action: [], warning: [], info: [] },
+    reactions: {},
+    progressChecks: { enabled: false, intervalMinutes: 10, terminalLines: 50, signals: { errorPatterns: [], testPatterns: [], livePatterns: [] } },
+    ...overrides,
+  } as OrchestratorConfig;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("computeAccountCapacity", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns 100% remaining when nothing consumed", () => {
+    const config = makeConfig();
+    const state = makeState({ accountId: "test" });
+    const result = computeAccountCapacity("test", config, state, 0);
+
+    expect(result.baseQuota.percentRemaining).toBe(100);
+    expect(result.baseQuota.consumed).toBe(0);
+    expect(result.baseQuota.remaining).toBe(100);
+    expect(result.status).toBe("available");
+  });
+
+  it("calculates remaining correctly after consumption", () => {
+    const config = makeConfig();
+    const state = makeState({
+      accountId: "test",
+      consumed: 25,
+      windowStartedAt: new Date("2026-01-15T10:00:00Z").toISOString(),
+    });
+    const result = computeAccountCapacity("test", config, state, 2);
+
+    expect(result.baseQuota.consumed).toBe(25);
+    expect(result.baseQuota.remaining).toBe(75);
+    expect(result.baseQuota.percentRemaining).toBe(75);
+    expect(result.activeSessions).toBe(2);
+    expect(result.status).toBe("available");
+  });
+
+  it("returns fully-exhausted when quota consumed and no overage", () => {
+    const config = makeConfig();
+    const state = makeState({
+      accountId: "test",
+      consumed: 100,
+      windowStartedAt: new Date("2026-01-15T10:00:00Z").toISOString(),
+    });
+    const result = computeAccountCapacity("test", config, state, 0);
+
+    expect(result.baseQuota.remaining).toBe(0);
+    expect(result.baseQuota.percentRemaining).toBe(0);
+    expect(result.status).toBe("fully-exhausted");
+  });
+
+  it("returns overage-only when quota exhausted but overage available", () => {
+    const config = makeConfig({
+      overage: { enabled: true, type: "credits", spendCap: 50 },
+    });
+    const state = makeState({
+      accountId: "test",
+      consumed: 100,
+      windowStartedAt: new Date("2026-01-15T10:00:00Z").toISOString(),
+      overageConsumed: 10,
+    });
+    const result = computeAccountCapacity("test", config, state, 0);
+
+    expect(result.status).toBe("overage-only");
+    expect(result.overage).not.toBeNull();
+    expect(result.overage?.consumed).toBe(10);
+    expect(result.overage?.remaining).toBe(40);
+  });
+
+  it("resets effective consumed when window has expired", () => {
+    const config = makeConfig({ baseQuota: { estimatedTotal: 100, windowHours: 5 } });
+    // Window started 6 hours ago → expired
+    const state = makeState({
+      accountId: "test",
+      consumed: 80,
+      windowStartedAt: new Date("2026-01-15T06:00:00Z").toISOString(),
+    });
+    const result = computeAccountCapacity("test", config, state, 0);
+
+    // Window expired, so effectiveConsumed is 0
+    expect(result.baseQuota.consumed).toBe(0);
+    expect(result.baseQuota.remaining).toBe(100);
+    expect(result.status).toBe("available");
+  });
+
+  it("shows window reset time when window is active", () => {
+    const config = makeConfig({ baseQuota: { estimatedTotal: 100, windowHours: 5 } });
+    // Window started 2 hours ago → 3 hours remaining
+    const state = makeState({
+      accountId: "test",
+      consumed: 10,
+      windowStartedAt: new Date("2026-01-15T10:00:00Z").toISOString(),
+    });
+    const result = computeAccountCapacity("test", config, state, 0);
+
+    expect(result.baseQuota.windowResetIn).toBe("3h");
+  });
+
+  it("returns null for windowResetIn when no window started", () => {
+    const config = makeConfig();
+    const state = makeState({ accountId: "test", windowStartedAt: null });
+    const result = computeAccountCapacity("test", config, state, 0);
+
+    expect(result.baseQuota.windowResetIn).toBeNull();
+  });
+
+  it("uses 100% remaining when no estimatedTotal configured", () => {
+    const config: AccountConfig = { agent: "codex" };
+    const state = makeState({ accountId: "test", consumed: 5 });
+    const result = computeAccountCapacity("test", config, state, 0);
+
+    expect(result.baseQuota.estimatedTotal).toBe(0);
+    expect(result.baseQuota.percentRemaining).toBe(100);
+    expect(result.status).toBe("available");
+  });
+});
+
+describe("getEffectiveAccounts", () => {
+  it("returns explicit accounts from config", () => {
+    const config = makeOrchestratorConfig({
+      accounts: {
+        "codex-pro-1": { agent: "codex" },
+        "claude-max-1": { agent: "claude-code" },
+      },
+    });
+    const accounts = getEffectiveAccounts(config);
+
+    expect(accounts["codex-pro-1"]).toBeDefined();
+    expect(accounts["claude-max-1"]).toBeDefined();
+  });
+
+  it("derives implicit accounts from project agents", () => {
+    const config = makeOrchestratorConfig(); // default agent is claude-code
+    const accounts = getEffectiveAccounts(config);
+
+    // Should have implicit "claude-code" account
+    expect(accounts["claude-code"]).toBeDefined();
+    expect(accounts["claude-code"]?.agent).toBe("claude-code");
+  });
+
+  it("does not duplicate agents already covered by explicit accounts", () => {
+    const config = makeOrchestratorConfig({
+      accounts: {
+        "my-claude": { agent: "claude-code" },
+      },
+    });
+    const accounts = getEffectiveAccounts(config);
+
+    // "claude-code" should only appear as "my-claude", not also as "claude-code"
+    expect(accounts["my-claude"]).toBeDefined();
+    expect(accounts["claude-code"]).toBeUndefined();
+  });
+});
+
+describe("resolveAccountForProject", () => {
+  it("resolves to agent name when no explicit accounts", () => {
+    const config = makeOrchestratorConfig();
+    const accountId = resolveAccountForProject(config, "my-app");
+
+    // Default agent is "claude-code" for my-app
+    expect(accountId).toBe("claude-code");
+  });
+
+  it("resolves to first matching explicit account", () => {
+    const config = makeOrchestratorConfig({
+      accounts: {
+        "codex-pro-1": { agent: "codex" },
+        "claude-max-1": { agent: "claude-code" },
+      },
+    });
+    const accountId = resolveAccountForProject(config, "my-app");
+
+    // my-app uses default agent "claude-code" → "claude-max-1"
+    expect(accountId).toBe("claude-max-1");
+  });
+
+  it("falls back to agent name when no explicit account matches", () => {
+    const config = makeOrchestratorConfig({
+      accounts: {
+        "codex-pro-1": { agent: "codex" },
+      },
+    });
+    const accountId = resolveAccountForProject(config, "my-app");
+
+    // my-app uses "claude-code", no explicit claude-code account → fallback
+    expect(accountId).toBe("claude-code");
+  });
+});

--- a/packages/cli/src/commands/capacity.ts
+++ b/packages/cli/src/commands/capacity.ts
@@ -1,0 +1,187 @@
+/**
+ * `syn capacity` — show per-account capacity and headroom.
+ *
+ * Usage:
+ *   syn capacity                  # Show all accounts
+ *   syn capacity --agent codex    # Filter to Codex accounts
+ *   syn capacity --available      # Only accounts with remaining quota
+ *   syn capacity --json           # Machine-readable output
+ */
+
+import chalk from "chalk";
+import type { Command } from "commander";
+import { loadConfig, type AccountCapacity } from "@syntese/core";
+import {
+  computeAccountCapacity,
+  getEffectiveAccounts,
+  readCapacityState,
+} from "../lib/capacity-store.js";
+import { getSessionManager } from "../lib/create-session-manager.js";
+import { banner, padCol } from "../lib/format.js";
+
+// ─── Display Helpers ─────────────────────────────────────────────────────────
+
+const COL = {
+  account: 16,
+  agent: 13,
+  quota: 18,
+  overage: 16,
+  sessions: 10,
+};
+
+function statusColor(status: AccountCapacity["status"]): string {
+  switch (status) {
+    case "available":
+      return chalk.green(status);
+    case "quota-exhausted":
+      return chalk.yellow(status);
+    case "overage-only":
+      return chalk.magenta(status);
+    case "fully-exhausted":
+      return chalk.red(status);
+  }
+}
+
+function formatQuota(capacity: AccountCapacity): string {
+  const q = capacity.baseQuota;
+  if (q.estimatedTotal === 0) {
+    return chalk.dim("—");
+  }
+  const pct = `${q.percentRemaining}%`;
+  const frac = `(${q.consumed}/${q.estimatedTotal})`;
+  const color = q.percentRemaining > 30 ? chalk.green : q.percentRemaining > 10 ? chalk.yellow : chalk.red;
+  return `${color(pct)} ${chalk.dim(frac)}`;
+}
+
+function formatOverage(capacity: AccountCapacity): string {
+  if (!capacity.overage || !capacity.overage.enabled) {
+    return chalk.dim("disabled");
+  }
+  const o = capacity.overage;
+  const typeLabel = o.type === "api-rates" ? "api" : "credits";
+  return chalk.dim(`${typeLabel}: $${o.consumed.toFixed(0)}/$${o.spendCap}`);
+}
+
+function printTableHeader(): void {
+  const hdr =
+    padCol("Account", COL.account) +
+    padCol("Agent", COL.agent) +
+    padCol("Base Quota", COL.quota) +
+    padCol("Overage", COL.overage) +
+    padCol("Sessions", COL.sessions) +
+    "Status";
+  console.log(chalk.dim(`  ${hdr}`));
+  const totalWidth = COL.account + COL.agent + COL.quota + COL.overage + COL.sessions + 12;
+  console.log(chalk.dim(`  ${"─".repeat(totalWidth)}`));
+}
+
+function printCapacityRow(capacity: AccountCapacity): void {
+  const row =
+    padCol(chalk.cyan(capacity.accountId), COL.account) +
+    padCol(chalk.dim(capacity.agent), COL.agent) +
+    padCol(formatQuota(capacity), COL.quota) +
+    padCol(formatOverage(capacity), COL.overage) +
+    padCol(String(capacity.activeSessions), COL.sessions) +
+    statusColor(capacity.status);
+  console.log(`  ${row}`);
+}
+
+// ─── Command Registration ─────────────────────────────────────────────────────
+
+export function registerCapacity(program: Command): void {
+  program
+    .command("capacity")
+    .description("Show per-account capacity and headroom")
+    .option("--agent <type>", "Filter to accounts for this agent type (e.g. codex, claude-code)")
+    .option("--available", "Only show accounts with remaining quota")
+    .option("--json", "Output as JSON")
+    .action(
+      async (opts: { agent?: string; available?: boolean; json?: boolean }) => {
+        let config: ReturnType<typeof loadConfig>;
+        try {
+          config = loadConfig();
+        } catch {
+          console.error(chalk.red("No config found. Run `syn init` first."));
+          process.exit(1);
+        }
+
+        // Get active sessions per accountId (count from session manager)
+        const activeSessionsByAccount = new Map<string, number>();
+        try {
+          const sm = await getSessionManager(config);
+          const sessions = await sm.list();
+          for (const session of sessions) {
+            if (["working", "spawning", "idle", "ready"].includes(session.status)) {
+              const agentName = config.projects[session.projectId]?.agent ?? config.defaults.agent;
+              // Map to account using the same logic as resolveAccountForProject
+              let accountId = agentName;
+              if (config.accounts) {
+                for (const [id, acctCfg] of Object.entries(config.accounts)) {
+                  if (acctCfg.agent === agentName) {
+                    accountId = id;
+                    break;
+                  }
+                }
+              }
+              activeSessionsByAccount.set(accountId, (activeSessionsByAccount.get(accountId) ?? 0) + 1);
+            }
+          }
+        } catch {
+          // Session manager unavailable — proceed with zero active sessions
+        }
+
+        const accounts = getEffectiveAccounts(config);
+
+        // Load states and compute capacities in parallel
+        const entries = Object.entries(accounts);
+        const capacities = await Promise.all(
+          entries.map(async ([accountId, accountConfig]) => {
+            const state = await readCapacityState(accountId);
+            const activeSessions = activeSessionsByAccount.get(accountId) ?? 0;
+            return computeAccountCapacity(accountId, accountConfig, state, activeSessions);
+          }),
+        );
+
+        // Apply filters
+        let filtered = capacities;
+        if (opts.agent) {
+          filtered = filtered.filter((c) => c.agent === opts.agent);
+        }
+        if (opts.available) {
+          filtered = filtered.filter((c) => c.status === "available" || c.status === "overage-only");
+        }
+
+        if (opts.json) {
+          console.log(JSON.stringify(filtered, null, 2));
+          return;
+        }
+
+        console.log(banner("SYNTESE CAPACITY"));
+        console.log();
+
+        if (filtered.length === 0) {
+          console.log(chalk.dim("  No accounts found."));
+          console.log();
+          return;
+        }
+
+        printTableHeader();
+        for (const capacity of filtered) {
+          printCapacityRow(capacity);
+        }
+        console.log();
+
+        const windowNote = filtered.some((c) => c.baseQuota.windowResetIn !== null);
+        if (windowNote) {
+          for (const c of filtered) {
+            if (c.baseQuota.windowResetIn) {
+              console.log(
+                chalk.dim(`  ${c.accountId}: window resets in ${c.baseQuota.windowResetIn}`),
+              );
+            }
+          }
+          console.log();
+        }
+      },
+    );
+}

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -18,6 +18,10 @@ import { banner } from "../lib/format.js";
 import { getSessionManager } from "../lib/create-session-manager.js";
 import { ensureLifecycleWorker } from "../lib/lifecycle-service.js";
 import { preflight } from "../lib/preflight.js";
+import {
+  incrementAccountConsumed,
+  resolveAccountForProject,
+} from "../lib/capacity-store.js";
 
 interface SpawnClaimOptions {
   claimPr?: string;
@@ -91,6 +95,12 @@ async function spawnSession(
         ? `Session ${chalk.green(session.id)} created and claimed PR`
         : `Session ${chalk.green(session.id)} created`,
     );
+
+    // Track spawn in per-account capacity store (best-effort, non-blocking)
+    const accountId = resolveAccountForProject(config, projectId);
+    incrementAccountConsumed(accountId).catch(() => {
+      // Capacity tracking failure is non-fatal
+    });
 
     console.log(`  Worktree: ${chalk.dim(session.workspacePath ?? "-")}`);
     if (branchStr) console.log(`  Branch:   ${chalk.dim(branchStr)}`);

--- a/packages/cli/src/lib/capacity-store.ts
+++ b/packages/cli/src/lib/capacity-store.ts
@@ -1,0 +1,265 @@
+/**
+ * Per-account capacity tracking.
+ *
+ * Persists consumed-message counts and overage data per account.
+ * Storage: ~/.syntese/accounts/<accountId>/capacity.json
+ *
+ * Accounts are either explicitly configured under `accounts:` in syntese.yaml,
+ * or implicitly derived from the agent types used across projects (one default
+ * account per agent type, named after the agent).
+ */
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import {
+  getAccountCapacityFile,
+  type AccountCapacity,
+  type AccountCapacityStatus,
+  type AccountConfig,
+  type AccountOverage,
+  type OrchestratorConfig,
+} from "@syntese/core";
+
+// ─── Persisted State ─────────────────────────────────────────────────────────
+
+const CAPACITY_STATE_VERSION = 1;
+
+/** Persisted self-tracked state for one account. */
+export interface AccountCapacityState {
+  version: number;
+  accountId: string;
+  /** Number of sessions spawned since window start. */
+  consumed: number;
+  /** ISO timestamp when the current window started (first spawn). */
+  windowStartedAt: string | null;
+  /** Dollars or credits consumed in overage this window. */
+  overageConsumed: number;
+  /** Last update timestamp. */
+  updatedAt: string;
+}
+
+function defaultState(accountId: string): AccountCapacityState {
+  return {
+    version: CAPACITY_STATE_VERSION,
+    accountId,
+    consumed: 0,
+    windowStartedAt: null,
+    overageConsumed: 0,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+// ─── File I/O ─────────────────────────────────────────────────────────────────
+
+export async function readCapacityState(accountId: string): Promise<AccountCapacityState> {
+  const filePath = getAccountCapacityFile(accountId);
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "version" in parsed &&
+      "accountId" in parsed
+    ) {
+      return parsed as AccountCapacityState;
+    }
+    return defaultState(accountId);
+  } catch {
+    return defaultState(accountId);
+  }
+}
+
+export async function writeCapacityState(state: AccountCapacityState): Promise<void> {
+  const filePath = getAccountCapacityFile(state.accountId);
+  await mkdir(dirname(filePath), { recursive: true });
+  await writeFile(filePath, JSON.stringify(state, null, 2), "utf-8");
+}
+
+// ─── Spawn Tracking ───────────────────────────────────────────────────────────
+
+/**
+ * Increment consumed count for an account when a session is spawned.
+ * Starts the window clock if this is the first spawn.
+ */
+export async function incrementAccountConsumed(accountId: string): Promise<void> {
+  const state = await readCapacityState(accountId);
+  const now = new Date().toISOString();
+
+  state.consumed += 1;
+  state.updatedAt = now;
+  if (!state.windowStartedAt) {
+    state.windowStartedAt = now;
+  }
+
+  await writeCapacityState(state);
+}
+
+/**
+ * Calibrate consumed count from an external source (e.g. /status command output).
+ * If calibration shows less remaining than self-tracked, trust calibration.
+ */
+export async function calibrateAccountConsumed(
+  accountId: string,
+  externalConsumed: number,
+): Promise<void> {
+  const state = await readCapacityState(accountId);
+  // Trust the higher consumed count (external usage may have occurred outside Syntese)
+  if (externalConsumed > state.consumed) {
+    state.consumed = externalConsumed;
+    state.updatedAt = new Date().toISOString();
+    await writeCapacityState(state);
+  }
+}
+
+// ─── Capacity Computation ─────────────────────────────────────────────────────
+
+/** Format milliseconds as "Xh Ym" or "Ym" */
+function formatDuration(ms: number): string {
+  if (ms <= 0) return "0m";
+  const totalMinutes = Math.floor(ms / 60_000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours > 0 && minutes > 0) return `${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h`;
+  return `${minutes}m`;
+}
+
+function computeWindowResetIn(
+  windowStartedAt: string | null,
+  windowHours: number,
+): string | null {
+  if (!windowStartedAt) return null;
+  const startMs = new Date(windowStartedAt).getTime();
+  const windowMs = windowHours * 3600_000;
+  const resetAt = startMs + windowMs;
+  const remaining = resetAt - Date.now();
+  if (remaining <= 0) return "now";
+  return formatDuration(remaining);
+}
+
+function computeStatus(
+  percentRemaining: number,
+  overage: AccountOverage | null,
+): AccountCapacityStatus {
+  const hasQuota = percentRemaining > 0;
+  const hasOverage = overage !== null && overage.enabled && overage.remaining > 0;
+
+  if (hasQuota) return "available";
+  if (!hasQuota && hasOverage) return "overage-only";
+  if (!hasQuota && !hasOverage) return "fully-exhausted";
+  return "quota-exhausted";
+}
+
+/**
+ * Compute the real-time AccountCapacity from config, persisted state, and
+ * a live active-session count.
+ */
+export function computeAccountCapacity(
+  accountId: string,
+  config: AccountConfig,
+  state: AccountCapacityState,
+  activeSessions: number,
+): AccountCapacity {
+  const windowHours = config.baseQuota?.windowHours ?? 5;
+  const estimatedTotal = config.baseQuota?.estimatedTotal ?? 0;
+
+  // Check if window has expired; if so, treat consumed as 0 for display
+  let effectiveConsumed = state.consumed;
+  if (state.windowStartedAt) {
+    const windowMs = windowHours * 3600_000;
+    const elapsed = Date.now() - new Date(state.windowStartedAt).getTime();
+    if (elapsed >= windowMs) {
+      effectiveConsumed = 0;
+    }
+  }
+
+  const remaining = Math.max(0, estimatedTotal - effectiveConsumed);
+  const percentRemaining =
+    estimatedTotal > 0 ? Math.round((remaining / estimatedTotal) * 100) : 100;
+
+  const baseQuota = {
+    estimatedTotal,
+    consumed: effectiveConsumed,
+    remaining,
+    percentRemaining,
+    windowResetIn: computeWindowResetIn(state.windowStartedAt, windowHours),
+  };
+
+  let overage: AccountOverage | null = null;
+  if (config.overage?.enabled) {
+    const spendCap = config.overage.spendCap ?? 0;
+    const overageConsumed = state.overageConsumed;
+    overage = {
+      enabled: true,
+      type: config.overage.type ?? "credits",
+      consumed: overageConsumed,
+      spendCap,
+      remaining: Math.max(0, spendCap - overageConsumed),
+    };
+  }
+
+  const status = computeStatus(percentRemaining, overage);
+
+  return {
+    accountId,
+    agent: config.agent,
+    model: config.model ?? null,
+    baseQuota,
+    overage,
+    activeSessions,
+    status,
+  };
+}
+
+// ─── Account Derivation ───────────────────────────────────────────────────────
+
+/**
+ * Get all account configs: explicit ones from config.accounts plus implicit
+ * defaults derived from agent types used across projects.
+ *
+ * Implicit accounts use the agent name as both the accountId and agent field,
+ * with no quota limits (everything shows as "available" with no estimatedTotal).
+ */
+export function getEffectiveAccounts(config: OrchestratorConfig): Record<string, AccountConfig> {
+  const explicit = config.accounts ?? {};
+
+  // Derive implicit accounts from project agents not already covered
+  const agentsCovered = new Set(Object.values(explicit).map((a) => a.agent));
+
+  const implicit: Record<string, AccountConfig> = {};
+  for (const project of Object.values(config.projects)) {
+    const agentName = project.agent ?? config.defaults.agent;
+    if (!agentsCovered.has(agentName)) {
+      // Use agent name as accountId for the implicit default
+      implicit[agentName] = { agent: agentName };
+      agentsCovered.add(agentName);
+    }
+  }
+
+  return { ...implicit, ...explicit };
+}
+
+/**
+ * Resolve which accountId to use when spawning a session for a project.
+ * Prefers explicit account matching; falls back to agent-named default.
+ */
+export function resolveAccountForProject(
+  config: OrchestratorConfig,
+  projectId: string,
+): string {
+  const project = config.projects[projectId];
+  const agentName = project?.agent ?? config.defaults.agent;
+
+  // If an explicit account uses this agent, pick the first match
+  if (config.accounts) {
+    for (const [accountId, accountConfig] of Object.entries(config.accounts)) {
+      if (accountConfig.agent === agentName) {
+        return accountId;
+      }
+    }
+  }
+
+  // Fall back to the implicit agent-named account
+  return agentName;
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -12,6 +12,7 @@ import { registerStart, registerStop } from "./commands/start.js";
 import { registerLifecycleWorker } from "./commands/lifecycle-worker.js";
 import { registerServices } from "./commands/services.js";
 import { registerVerify } from "./commands/verify.js";
+import { registerCapacity } from "./commands/capacity.js";
 
 export function createProgram(): Command {
   const program = new Command();
@@ -36,6 +37,7 @@ export function createProgram(): Command {
   registerOpen(program);
   registerLifecycleWorker(program);
   registerVerify(program);
+  registerCapacity(program);
 
   return program;
 }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -212,6 +212,24 @@ const DefaultPluginsSchema = z.object({
   notifiers: z.array(z.string()).default(["composio", "desktop"]),
 });
 
+const AccountBaseQuotaSchema = z.object({
+  estimatedTotal: z.number().positive(),
+  windowHours: z.number().positive().optional(),
+});
+
+const AccountOverageSchema = z.object({
+  enabled: z.boolean(),
+  type: z.enum(["credits", "api-rates"]).optional(),
+  spendCap: z.number().nonnegative().optional(),
+});
+
+const AccountConfigSchema = z.object({
+  agent: z.string(),
+  model: z.string().optional(),
+  baseQuota: AccountBaseQuotaSchema.optional(),
+  overage: AccountOverageSchema.optional(),
+});
+
 const OrchestratorConfigSchema = z.object({
   port: z.number().default(3000),
   terminalPort: z.number().optional(),
@@ -228,6 +246,7 @@ const OrchestratorConfigSchema = z.object({
   }),
   reactions: z.record(ReactionConfigSchema).default({}),
   progressChecks: ProgressChecksSchema.default({}),
+  accounts: z.record(AccountConfigSchema).optional(),
 });
 
 // =============================================================================

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -154,6 +154,8 @@ export {
   parseTmuxName,
   expandHome,
   validateAndStoreOrigin,
+  getAccountDataDir,
+  getAccountCapacityFile,
 } from "./paths.js";
 
 // Config generator — auto-generate config from repo URL

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -186,6 +186,22 @@ export function parseTmuxName(tmuxName: string): {
 }
 
 /**
+ * Get the per-account capacity data directory.
+ * Format: ~/.syntese/accounts/<accountId>
+ */
+export function getAccountDataDir(accountId: string): string {
+  return join(getDataRootDir(), "accounts", accountId);
+}
+
+/**
+ * Get the capacity state file path for an account.
+ * Format: ~/.syntese/accounts/<accountId>/capacity.json
+ */
+export function getAccountCapacityFile(accountId: string): string {
+  return join(getAccountDataDir(accountId), "capacity.json");
+}
+
+/**
  * Expand ~ to home directory.
  */
 export function expandHome(filepath: string): string {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1029,6 +1029,70 @@ export interface OrchestratorConfig {
 
   /** Periodic per-session progress snapshots */
   progressChecks: ProgressChecksConfig;
+
+  /** Per-account capacity configuration (optional; backward compatible) */
+  accounts?: Record<string, AccountConfig>;
+}
+
+// =============================================================================
+// ACCOUNT CAPACITY
+// =============================================================================
+
+/** Account subscription/auth configuration */
+export interface AccountConfig {
+  /** Agent type this account belongs to */
+  agent: string;
+  /** Model identifier, e.g. "claude-opus-4" */
+  model?: string;
+  /** Base quota limits for the rolling window */
+  baseQuota?: {
+    /** Estimated total messages per window (e.g. 223 for Codex Pro) */
+    estimatedTotal: number;
+    /** Window duration in hours (default: 5) */
+    windowHours?: number;
+  };
+  /** Overage / spend-cap configuration */
+  overage?: {
+    enabled: boolean;
+    type?: "credits" | "api-rates";
+    /** Maximum spend cap in dollars or credits */
+    spendCap?: number;
+  };
+}
+
+/** Real-time headroom status for a single account */
+export type AccountCapacityStatus =
+  | "available"
+  | "quota-exhausted"
+  | "overage-only"
+  | "fully-exhausted";
+
+export interface AccountBaseQuota {
+  estimatedTotal: number;
+  consumed: number;
+  remaining: number;
+  percentRemaining: number;
+  /** Human-readable time until window reset, e.g. "2h 15m" */
+  windowResetIn: string | null;
+}
+
+export interface AccountOverage {
+  enabled: boolean;
+  type: "credits" | "api-rates";
+  consumed: number;
+  spendCap: number;
+  remaining: number;
+}
+
+/** Computed real-time capacity for a single account */
+export interface AccountCapacity {
+  accountId: string;
+  agent: string;
+  model: string | null;
+  baseQuota: AccountBaseQuota;
+  overage: AccountOverage | null;
+  activeSessions: number;
+  status: AccountCapacityStatus;
 }
 
 export interface DefaultPlugins {


### PR DESCRIPTION
## Summary

- Extends the usage dials system (#56) to track capacity per account rather than per agent type
- Adds `AccountCapacity`, `AccountConfig`, and related types to `@syntese/core`
- Adds optional `accounts:` section to `OrchestratorConfig` (fully backward compatible)
- New `packages/cli/src/lib/capacity-store.ts` — persistent self-tracked state at `~/.syntese/accounts/<id>/capacity.json`
- New `syn capacity` CLI command with `--agent`, `--available`, `--json` flags
- Spawn tracking: `incrementAccountConsumed()` called after each successful `syn spawn`
- 14 new tests for capacity computation, account derivation, and project→account resolution

## Design

- **Backward compatible:** single-account setups work without any config changes — implicit accounts are derived from the agent types used across projects
- **Explicit accounts:** configure in `syntese.yaml` under `accounts:` key for multi-account setups
- **Self-tracking:** consumed count increments on spawn; window expiry resets effective consumed to 0
- **Calibration hook:** `calibrateAccountConsumed()` exported for future integration with agent `/status` commands (as described in the issue)
- **Window math:** capacity shows `windowResetIn` from when the first spawn occurred in the current window

## Example output

```
╔════════════════════════════════════════════════════════════════════════════╗
║ SYNTESE CAPACITY                                                           ║
╚════════════════════════════════════════════════════════════════════════════╝

Account          Agent        Base Quota          Overage          Sessions  Status
────────────────────────────────────────────────────────────────────────────────
codex-pro-1      codex        87% (28/223)        credits: $12/$50 2         available
claude-max-1     claude-code  0% (150/150)        api: $8/$100     1         overage-only
claude-team-1    claude-code  45% (68/150)        disabled         0         available

  codex-pro-1: window resets in 3h 15m
  claude-max-1: window resets in 1h 45m
```

## Test plan

- [x] `pnpm run typecheck` — all packages pass
- [x] `pnpm run lint` — warnings only (pre-existing)
- [x] `pnpm test` — 228 tests pass across all packages (18 test files in CLI)
- [ ] Manual: `syn capacity` shows accounts from config
- [ ] Manual: `syn capacity --agent codex` filters correctly
- [ ] Manual: `syn capacity --json` returns structured JSON matching `AccountCapacity[]`
- [ ] Manual: `syn spawn <project>` increments consumed count visible in `syn capacity`

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)