### PR TITLE
feat: add max runtime stuck alerts

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -71,7 +71,7 @@ spawning → working → completed
 - `ci-failed` → send fix prompt to agent
 - `changes-requested` → send review comments to agent
 - `approved-and-green` → notify human (or auto-merge)
-- `agent-stuck` → notify human
+- `agent-stuck` → notify human (`threshold` for idle sessions, optional `maxRuntime` for no-PR timeouts)
 
 **Polling loop:**
 

--- a/packages/core/__tests__/config.test.ts
+++ b/packages/core/__tests__/config.test.ts
@@ -158,6 +158,38 @@ reactions:
       );
     });
 
+    it("loads agent-stuck maxRuntime alongside the default stuck settings", () => {
+      const configPath = join(testDir, "agent-stuck-config.yaml");
+      writeFileSync(
+        configPath,
+        `
+projects:
+  test-project:
+    repo: test/repo
+    path: ${testDir}
+    defaultBranch: main
+reactions:
+  agent-stuck:
+    auto: true
+    action: notify
+    maxRuntime: 30m
+`,
+      );
+
+      const config = loadConfig(configPath);
+
+      expect(config.reactions["agent-stuck"]).toEqual(
+        expect.objectContaining({
+          auto: true,
+          action: "notify",
+          priority: "urgent",
+          refireIntervalMs: 300_000,
+          threshold: "10m",
+          maxRuntime: "30m",
+        }),
+      );
+    });
+
     it("parses progressChecks config and normalizes notify to an array", () => {
       const configPath = join(testDir, "progress-config.yaml");
 

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -898,6 +898,207 @@ describe("check (single session)", () => {
     ]);
   });
 
+  it("marks long-running no-PR sessions as stuck when maxRuntime is exceeded", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T12:30:01.000Z"));
+
+    config.notificationRouting.urgent = ["desktop"];
+    config.reactions["agent-stuck"] = {
+      auto: true,
+      action: "notify",
+      priority: "urgent",
+      maxRuntime: "30m",
+    };
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const createdAt = new Date("2026-03-09T12:00:00.000Z");
+    const session = makeSession({
+      status: "working",
+      pr: null,
+      createdAt,
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      createdAt: createdAt.toISOString(),
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("stuck");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("stuck");
+    expect(vi.mocked(mockNotifier.notify).mock.calls.map(([event]) => event.type)).toEqual([
+      "reaction.triggered",
+    ]);
+  });
+
+  it("exempts sessions from maxRuntime once a PR is auto-detected", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T12:30:01.000Z"));
+
+    config.notificationRouting.urgent = ["desktop"];
+    config.reactions["agent-stuck"] = {
+      auto: true,
+      action: "notify",
+      priority: "urgent",
+      maxRuntime: "30m",
+    };
+
+    const pr = makePR();
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn().mockResolvedValue(pr),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("none"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("none"),
+      getPendingComments: vi.fn().mockResolvedValue([]),
+      getAutomatedComments: vi.fn().mockResolvedValue([]),
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: false,
+        ciPassing: false,
+        approved: false,
+        noConflicts: true,
+        blockers: ["ci"],
+      }),
+    };
+
+    const registryWithNotifierAndScm: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const createdAt = new Date("2026-03-09T12:00:00.000Z");
+    const session = makeSession({
+      status: "working",
+      pr: null,
+      branch: pr.branch,
+      createdAt,
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: pr.branch,
+      status: "working",
+      project: "my-app",
+      createdAt: createdAt.toISOString(),
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifierAndScm,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(mockSCM.detectPR).toHaveBeenCalledWith(session, config.projects["my-app"]);
+    expect(lm.getStates().get("app-1")).toBe("pr_open");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["pr"]).toBe(pr.url);
+    expect(mockNotifier.notify).not.toHaveBeenCalled();
+  });
+
+  it("re-fires maxRuntime stuck notifications after the configured interval", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T12:30:01.000Z"));
+
+    config.notificationRouting.urgent = ["desktop"];
+    config.reactions["agent-stuck"] = {
+      auto: true,
+      action: "notify",
+      priority: "urgent",
+      maxRuntime: "30m",
+      refireIntervalMs: 120_000,
+    };
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const createdAt = new Date("2026-03-09T12:00:00.000Z");
+    const session = makeSession({
+      status: "working",
+      pr: null,
+      createdAt,
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      createdAt: createdAt.toISOString(),
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    expect(mockNotifier.notify).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date("2026-03-09T12:32:00.000Z"));
+    await lm.check("app-1");
+    expect(mockNotifier.notify).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(new Date("2026-03-09T12:32:02.000Z"));
+    await lm.check("app-1");
+    expect(mockNotifier.notify).toHaveBeenCalledTimes(2);
+  });
+
   it("stays working when agent is idle but process is still running (fallback path)", async () => {
     vi.mocked(mockAgent.getActivityState).mockResolvedValue(null);
     vi.mocked(mockAgent.detectActivity).mockReturnValue("idle");

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -80,6 +80,7 @@ const ReactionConfigSchema = z.object({
   refireIntervalMs: z.number().nonnegative().optional(),
   escalateAfter: z.union([z.number(), z.string()]).optional(),
   threshold: z.string().optional(),
+  maxRuntime: z.string().optional(),
   includeSummary: z.boolean().optional(),
 });
 

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1547,17 +1547,31 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
   }
 
+  function getAgentStuckReactionConfig(session: Session): ReactionConfig | null {
+    return getReactionConfigForSession(session, "agent-stuck");
+  }
+
   /** Check if idle time exceeds the agent-stuck threshold. */
   function isIdleBeyondThreshold(session: Session, idleTimestamp: Date): boolean {
-    const stuckReaction =
-      config.projects[session.projectId]?.reactions?.["agent-stuck"] ??
-      config.reactions["agent-stuck"];
-    const thresholdStr = (stuckReaction as Record<string, unknown> | undefined)?.threshold;
+    const thresholdStr = getAgentStuckReactionConfig(session)?.threshold;
     if (typeof thresholdStr !== "string") return false;
     const stuckThresholdMs = parseDuration(thresholdStr);
     if (stuckThresholdMs <= 0) return false;
     const idleMs = Date.now() - idleTimestamp.getTime();
     return idleMs > stuckThresholdMs;
+  }
+
+  /** Check if session age exceeds the agent-stuck max runtime without a PR. */
+  function isBeyondMaxRuntime(session: Session): boolean {
+    const maxRuntimeStr = getAgentStuckReactionConfig(session)?.maxRuntime;
+    if (typeof maxRuntimeStr !== "string") return false;
+    const maxRuntimeMs = parseDuration(maxRuntimeStr);
+    if (maxRuntimeMs <= 0) return false;
+
+    const createdAtMs = session.createdAt.getTime();
+    if (!Number.isFinite(createdAtMs)) return false;
+
+    return Date.now() - createdAtMs > maxRuntimeMs;
   }
 
   async function evaluateOpenPR(
@@ -1913,6 +1927,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     if (preserveCurrentStatus) {
       return currentStatus;
+    }
+
+    if (!session.pr && isBeyondMaxRuntime(session)) {
+      return SESSION_STATUS.STUCK;
     }
 
     // 5. Agents can finish a turn without exiting. When they become ready/idle and

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -974,6 +974,9 @@ export interface ReactionConfig {
   /** Threshold duration for time-based triggers (e.g. "10m" for stuck detection) */
   threshold?: string;
 
+  /** Maximum session age before agent-stuck fires when no PR exists (e.g. "30m") */
+  maxRuntime?: string;
+
   /** Whether to include a summary in the notification */
   includeSummary?: boolean;
 }


### PR DESCRIPTION
## Summary
- add `maxRuntime` to the `agent-stuck` reaction config and schema
- mark sessions as `stuck` when their age exceeds `maxRuntime` and no PR exists
- add coverage for no-PR timeouts, PR auto-detect exemption, and stuck refire behavior

## Notes
- the max-runtime clock uses the session `createdAt` timestamp and does not reset on `ao send`
- sessions that auto-detect or already have a PR remain exempt from the timeout

## Validation
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run lint`

Closes #71