### PR TITLE
feat: enforce progress checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ reactions:
     auto: true
     action: send-to-agent
     retries: 2
+  progress-checkpoints:
+    firstCommit: 15m
+    firstPR: 45m
+    action: send-to-agent
+    checkpointMessage: Please push your current progress and open a draft PR.
   changes-requested:
     auto: true
     action: send-to-agent
@@ -155,7 +160,7 @@ reactions:
     action: notify
 ```
 
-CI fails → agent gets the logs and fixes it. Reviewer requests changes → agent addresses them. PR approved with green CI → you get a notification to merge.
+CI fails → agent gets the logs and fixes it. Reviewers request changes → agent addresses them. Progress checkpoints nudge slow-to-commit sessions back onto a commit/PR workflow. PR approved with green CI → you get a notification to merge.
 
 If a project needs live verification beyond CI, `verification.postPush` runs a project-defined command after each new pushed `HEAD`. `block-merge` prevents auto-merge and the dashboard merge action until that verification passes.
 

--- a/packages/cli/__tests__/commands/send.test.ts
+++ b/packages/cli/__tests__/commands/send.test.ts
@@ -17,6 +17,11 @@ const { mockConfigRef, mockSessionManager } = vi.hoisted(() => ({
   },
 }));
 
+const { mockGetSessionsDir, mockUpdateMetadata } = vi.hoisted(() => ({
+  mockGetSessionsDir: vi.fn(() => "/tmp/sessions"),
+  mockUpdateMetadata: vi.fn(),
+}));
+
 vi.mock("../../src/lib/shell.js", () => ({
   tmux: mockTmux,
   exec: mockExec,
@@ -49,6 +54,8 @@ vi.mock("@syntese/core", () => ({
     }
     return mockConfigRef.current;
   },
+  getSessionsDir: mockGetSessionsDir,
+  updateMetadata: mockUpdateMetadata,
 }));
 
 vi.mock("../../src/lib/create-session-manager.js", () => ({
@@ -78,6 +85,8 @@ beforeEach(() => {
   mockDetectActivity.mockReset();
   mockSessionManager.get.mockReset();
   mockSessionManager.send.mockReset();
+  mockGetSessionsDir.mockClear();
+  mockUpdateMetadata.mockClear();
   mockConfigRef.current = null;
   mockExec.mockResolvedValue({ stdout: "", stderr: "" });
 });
@@ -321,6 +330,14 @@ describe("send command", () => {
       await program.parseAsync(["node", "test", "send", "app-1", "hello", "opencode"]);
 
       expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "hello opencode");
+      expect(mockGetSessionsDir).toHaveBeenCalledWith("/tmp/syntese.yaml", "/tmp/my-app");
+      expect(mockUpdateMetadata).toHaveBeenCalledWith(
+        "/tmp/sessions",
+        "app-1",
+        expect.objectContaining({
+          progressCheckpointResetAt: expect.any(String),
+        }),
+      );
       expect(mockExec).not.toHaveBeenCalledWith(
         "tmux",
         expect.arrayContaining(["send-keys", "-l", "hello opencode"]),

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -6,8 +6,11 @@ import type { Command } from "commander";
 import {
   type Agent,
   type OpenCodeSessionManager,
+  type OrchestratorConfig,
   type Session,
+  getSessionsDir,
   loadConfig,
+  updateMetadata,
 } from "@syntese/core";
 import { exec, tmux } from "../lib/shell.js";
 import { getAgentByName } from "../lib/plugins.js";
@@ -18,6 +21,7 @@ import { getSessionManager } from "../lib/create-session-manager.js";
  * Loads config and looks up the session once, avoiding duplicate work.
  */
 async function resolveSessionContext(sessionName: string): Promise<{
+  config: OrchestratorConfig | null;
   tmuxTarget: string;
   runtimeName?: string;
   agent: Agent;
@@ -35,6 +39,7 @@ async function resolveSessionContext(sessionName: string): Promise<{
       const runtimeName =
         session.runtimeHandle?.runtimeName ?? project?.runtime ?? config.defaults.runtime;
       return {
+        config,
         tmuxTarget,
         runtimeName,
         agent: getAgentByName(agentName),
@@ -46,12 +51,32 @@ async function resolveSessionContext(sessionName: string): Promise<{
     // No config or session not found — fall back to defaults
   }
   return {
+    config: null,
     tmuxTarget: sessionName,
     runtimeName: "tmux",
     agent: getAgentByName("claude-code"),
     session: null,
     sessionManager: null,
   };
+}
+
+function markProgressCheckpointReset(
+  config: OrchestratorConfig | null,
+  session: Session | null,
+): void {
+  if (!config || !session) {
+    return;
+  }
+
+  const project = config.projects[session.projectId];
+  if (!project) {
+    return;
+  }
+
+  const sessionsDir = getSessionsDir(config.configPath, project.path);
+  updateMetadata(sessionsDir, session.id, {
+    progressCheckpointResetAt: new Date().toISOString(),
+  });
 }
 
 function isActive(agent: Agent, terminalOutput: string): boolean {
@@ -127,6 +152,7 @@ export function registerSend(program: Command): void {
       ) => {
         // Resolve session context once: tmux target, agent plugin, session data
         const {
+          config,
           tmuxTarget,
           runtimeName,
           agent,
@@ -184,6 +210,7 @@ export function registerSend(program: Command): void {
 
         if (existingSession && sessionManager) {
           await sessionManager.send(session, message);
+          markProgressCheckpointReset(config, existingSession);
           console.log(chalk.green("Message sent and processing"));
           return;
         }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -70,6 +70,7 @@ spawning → working → completed
 
 - `ci-failed` → send fix prompt to agent
 - `changes-requested` → send review comments to agent
+- `progress-checkpoints` → nudge sessions that miss early commit/PR milestones
 - `approved-and-green` → notify human (or auto-merge)
 - `agent-stuck` → notify human (`threshold` for idle sessions, optional `maxRuntime` for no-PR timeouts)
 

--- a/packages/core/__tests__/config.test.ts
+++ b/packages/core/__tests__/config.test.ts
@@ -230,6 +230,40 @@ progressChecks:
       expect(config.progressChecks.signals.testPatterns).toContain("pnpm test");
     });
 
+    it("parses progress checkpoint reactions and merges checkpoint defaults", () => {
+      const configPath = join(testDir, "checkpoint-reaction-config.yaml");
+
+      writeFileSync(
+        configPath,
+        `
+projects:
+  test-project:
+    repo: test/repo
+    path: ${testDir}
+    defaultBranch: main
+reactions:
+  progress-checkpoints:
+    firstCommit: 15m
+    firstPR: 45m
+    action: send-to-agent
+    checkpointMessage: Push your work now
+`,
+      );
+
+      const config = loadConfig(configPath);
+
+      expect(config.reactions["progress-checkpoints"]).toEqual(
+        expect.objectContaining({
+          auto: true,
+          action: "send-to-agent",
+          priority: "warning",
+          firstCommit: "15m",
+          firstPR: "45m",
+          checkpointMessage: "Push your work now",
+        }),
+      );
+    });
+
     it("loads project verification config", () => {
       const configPath = join(testDir, "verification-config.yaml");
       writeFileSync(

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -404,6 +404,293 @@ describe("progress snapshots", () => {
   });
 });
 
+describe("progress checkpoints", () => {
+  it("fires the firstCommit checkpoint once and records metadata", async () => {
+    config.notificationRouting.warning = ["desktop"];
+    config.reactions = {
+      "progress-checkpoints": {
+        auto: true,
+        action: "notify",
+        priority: "warning",
+        firstCommit: "15m",
+      },
+    };
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const createdAt = new Date(Date.now() - 20 * 60_000);
+    const session = makeSession({
+      status: "working",
+      workspacePath: null,
+      createdAt,
+      metadata: {
+        status: "working",
+        project: "my-app",
+        branch: "feat/test",
+        createdAt: createdAt.toISOString(),
+      },
+    });
+
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "feat/test",
+      status: "working",
+      project: "my-app",
+      createdAt: createdAt.toISOString(),
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(mockNotifier.notify).toHaveBeenCalledTimes(1);
+    expect(mockNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "reaction.triggered",
+        priority: "warning",
+      }),
+    );
+    expect(mockNotifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          reactionKey: "progress-checkpoints",
+          checkpoint: "firstCommit",
+          missCount: 1,
+        }),
+      }),
+    );
+
+    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["progressCheckpointFirstCommitFiredAt"]).toBeDefined();
+    expect(metadata?.["progressCheckpointMissCount"]).toBe("1");
+
+    await lm.check("app-1");
+
+    expect(mockNotifier.notify).toHaveBeenCalledTimes(1);
+  });
+
+  it("escalates the second missed checkpoint to urgent", async () => {
+    config.notificationRouting.warning = ["desktop"];
+    config.notificationRouting.urgent = ["desktop"];
+    config.reactions = {
+      "progress-checkpoints": {
+        auto: true,
+        action: "notify",
+        priority: "warning",
+        firstCommit: "15m",
+        firstPR: "45m",
+      },
+    };
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const createdAt = new Date(Date.now() - 50 * 60_000);
+    const session = makeSession({
+      status: "working",
+      workspacePath: null,
+      createdAt,
+      metadata: {
+        status: "working",
+        project: "my-app",
+        branch: "feat/test",
+        createdAt: createdAt.toISOString(),
+      },
+    });
+
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "feat/test",
+      status: "working",
+      project: "my-app",
+      createdAt: createdAt.toISOString(),
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    await lm.check("app-1");
+
+    expect(mockNotifier.notify).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(mockNotifier.notify).mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        priority: "warning",
+        data: expect.objectContaining({ checkpoint: "firstCommit", missCount: 1 }),
+      }),
+    );
+    expect(vi.mocked(mockNotifier.notify).mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        priority: "urgent",
+        data: expect.objectContaining({ checkpoint: "firstPR", missCount: 2 }),
+      }),
+    );
+  });
+
+  it("uses progressCheckpointResetAt as the checkpoint baseline", async () => {
+    config.notificationRouting.warning = ["desktop"];
+    config.reactions = {
+      "progress-checkpoints": {
+        auto: true,
+        action: "notify",
+        priority: "warning",
+        firstCommit: "15m",
+      },
+    };
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const createdAt = new Date(Date.now() - 60 * 60_000);
+    const resetAt = new Date(Date.now() - 5 * 60_000).toISOString();
+    const session = makeSession({
+      status: "working",
+      workspacePath: null,
+      createdAt,
+      metadata: {
+        status: "working",
+        project: "my-app",
+        branch: "feat/test",
+        createdAt: createdAt.toISOString(),
+        progressCheckpointResetAt: resetAt,
+      },
+    });
+
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "feat/test",
+      status: "working",
+      project: "my-app",
+      createdAt: createdAt.toISOString(),
+      progressCheckpointResetAt: resetAt,
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(mockNotifier.notify).not.toHaveBeenCalled();
+  });
+
+  it("sends the configured checkpoint nudge to the agent", async () => {
+    config.notificationRouting.warning = ["desktop"];
+    config.reactions = {
+      "progress-checkpoints": {
+        auto: true,
+        action: "send-to-agent",
+        firstPR: "45m",
+        checkpointMessage: "Please push your current branch and open a draft PR now.",
+      },
+    };
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const createdAt = new Date(Date.now() - 50 * 60_000);
+    const session = makeSession({
+      status: "working",
+      workspacePath: null,
+      createdAt,
+      metadata: {
+        status: "working",
+        project: "my-app",
+        branch: "feat/test",
+        createdAt: createdAt.toISOString(),
+      },
+    });
+
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "feat/test",
+      status: "working",
+      project: "my-app",
+      createdAt: createdAt.toISOString(),
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(mockSessionManager.send).toHaveBeenCalledWith(
+      "app-1",
+      "Please push your current branch and open a draft PR now.",
+    );
+    expect(mockNotifier.notify).not.toHaveBeenCalled();
+  });
+});
+
 describe("poll logging", () => {
   it("logs poll boundaries, transitions, and notification results", async () => {
     config.notificationRouting.info = ["desktop"];

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -81,6 +81,9 @@ const ReactionConfigSchema = z.object({
   escalateAfter: z.union([z.number(), z.string()]).optional(),
   threshold: z.string().optional(),
   maxRuntime: z.string().optional(),
+  firstCommit: z.string().optional(),
+  firstPR: z.string().optional(),
+  checkpointMessage: z.string().optional(),
   includeSummary: z.boolean().optional(),
 });
 
@@ -408,6 +411,11 @@ function applyDefaultReactions(config: OrchestratorConfig): OrchestratorConfig {
       priority: "urgent",
       refireIntervalMs: 300_000,
       threshold: "10m",
+    },
+    "progress-checkpoints": {
+      auto: true,
+      action: "notify",
+      priority: "warning",
     },
     "agent-needs-input": {
       auto: true,

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -446,6 +446,23 @@ interface ProgressGitState {
   hasPushed: boolean;
 }
 
+type ProgressCheckpointKey = "firstCommit" | "firstPR";
+
+interface ProgressCheckpointCandidate {
+  key: ProgressCheckpointKey;
+  threshold: string;
+  thresholdMs: number;
+  gitState: ProgressGitState | null;
+}
+
+const PROGRESS_CHECKPOINT_REACTION_KEY = "progress-checkpoints";
+const PROGRESS_CHECKPOINT_RESET_AT_METADATA_KEY = "progressCheckpointResetAt";
+const PROGRESS_CHECKPOINT_MISS_COUNT_METADATA_KEY = "progressCheckpointMissCount";
+const PROGRESS_CHECKPOINT_FIRED_AT_METADATA_KEYS: Record<ProgressCheckpointKey, string> = {
+  firstCommit: "progressCheckpointFirstCommitFiredAt",
+  firstPR: "progressCheckpointFirstPRFiredAt",
+};
+
 function createProgressSignalHistory(): ProgressSignalHistory {
   return {
     errorPatterns: new Set<string>(),
@@ -711,6 +728,15 @@ function createProgressSnapshotIdempotencyKey(
 ): string {
   return createHash("sha256")
     .update([sessionId, "progress-check", String(snapshotNumber)].join(":"))
+    .digest("hex");
+}
+
+function createProgressCheckpointIdempotencyKey(
+  sessionId: SessionId,
+  checkpointKey: ProgressCheckpointKey,
+): string {
+  return createHash("sha256")
+    .update([sessionId, "progress-checkpoint", checkpointKey].join(":"))
     .digest("hex");
 }
 
@@ -1026,6 +1052,59 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         error,
       });
       return fallbackMessage;
+    }
+  }
+
+  function resolveProgressCheckpointBaseAtMs(session: Session): number {
+    const resetAtMs = parseTimestampMs(session.metadata[PROGRESS_CHECKPOINT_RESET_AT_METADATA_KEY]);
+    if (resetAtMs === null) {
+      return session.createdAt.getTime();
+    }
+
+    return Math.max(session.createdAt.getTime(), resetAtMs);
+  }
+
+  function resolveProgressCheckpointPriority(
+    priority: EventPriority | undefined,
+    missCount: number,
+  ): EventPriority {
+    if (missCount >= 2) {
+      return "urgent";
+    }
+
+    return priority ?? "warning";
+  }
+
+  function buildProgressCheckpointNotificationMessage(
+    session: Session,
+    checkpoint: ProgressCheckpointCandidate,
+  ): string {
+    switch (checkpoint.key) {
+      case "firstCommit":
+        return `${session.id}: missed firstCommit checkpoint after ${checkpoint.threshold} without any commits`;
+      case "firstPR":
+        return `${session.id}: missed firstPR checkpoint after ${checkpoint.threshold} without opening a PR`;
+      default:
+        return `${session.id}: missed progress checkpoint`;
+    }
+  }
+
+  function buildProgressCheckpointAgentMessage(
+    reactionConfig: ReactionConfig,
+    checkpoint: ProgressCheckpointCandidate,
+  ): string {
+    const configuredMessage = reactionConfig.checkpointMessage ?? reactionConfig.message;
+    if (configuredMessage) {
+      return configuredMessage;
+    }
+
+    switch (checkpoint.key) {
+      case "firstCommit":
+        return `You've been working for ${checkpoint.threshold} without making any commits. Please commit your current progress, push it, and open a draft PR if the work is ready for review.`;
+      case "firstPR":
+        return `You've been working for ${checkpoint.threshold} without opening a PR. Please push your current progress and open a draft PR now.`;
+      default:
+        return "Please push your current progress and open a draft PR.";
     }
   }
 
@@ -2500,6 +2579,185 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     if (reactionConfig.auto === false) return null;
     return reactionConfig;
   }
+
+  function getProgressCheckpointConfigForSession(session: Session): ReactionConfig | null {
+    const reactionConfig = getReactionConfigForSession(session, PROGRESS_CHECKPOINT_REACTION_KEY);
+    if (!reactionConfig) {
+      return null;
+    }
+
+    const firstCommitThreshold =
+      typeof reactionConfig.firstCommit === "string" ? reactionConfig.firstCommit : null;
+    const firstPrThreshold = typeof reactionConfig.firstPR === "string" ? reactionConfig.firstPR : null;
+    const firstCommitMs = firstCommitThreshold ? parseDuration(firstCommitThreshold) : 0;
+    const firstPrMs = firstPrThreshold ? parseDuration(firstPrThreshold) : 0;
+
+    if (firstCommitMs <= 0 && firstPrMs <= 0) {
+      return null;
+    }
+
+    return reactionConfig;
+  }
+
+  async function fireProgressCheckpoint(
+    session: Session,
+    reactionConfig: ReactionConfig,
+    checkpoint: ProgressCheckpointCandidate,
+    pollStats?: LifecyclePollStats,
+  ): Promise<void> {
+    const now = new Date();
+    const nowMs = now.getTime();
+    const nowIso = now.toISOString();
+    const missCount = parseInteger(session.metadata[PROGRESS_CHECKPOINT_MISS_COUNT_METADATA_KEY]) + 1;
+    const priority = resolveProgressCheckpointPriority(reactionConfig.priority, missCount);
+    const checkpointBaseAtMs = resolveProgressCheckpointBaseAtMs(session);
+    const firedAtKey = PROGRESS_CHECKPOINT_FIRED_AT_METADATA_KEYS[checkpoint.key];
+
+    updateSessionMetadata(session, {
+      [firedAtKey]: nowIso,
+      [PROGRESS_CHECKPOINT_MISS_COUNT_METADATA_KEY]: String(missCount),
+    });
+
+    logLifecycle("info", "progress_checkpoint.triggered", {
+      pollId: pollStats?.pollId,
+      projectId: session.projectId,
+      sessionId: session.id,
+      checkpoint: checkpoint.key,
+      threshold: checkpoint.threshold,
+      missCount,
+      priority,
+    });
+
+    const event = createEvent("reaction.triggered", {
+      sessionId: session.id,
+      projectId: session.projectId,
+      message: buildProgressCheckpointNotificationMessage(session, checkpoint),
+      data: {
+        reactionKey: PROGRESS_CHECKPOINT_REACTION_KEY,
+        checkpoint: checkpoint.key,
+        threshold: checkpoint.threshold,
+        missCount,
+        checkpointPriority: priority,
+        checkpointBaseAt: new Date(checkpointBaseAtMs).toISOString(),
+        checkpointAgeMinutes: toElapsedMinutes(checkpointBaseAtMs, nowMs),
+        sessionAgeMinutes: toElapsedMinutes(session.createdAt.getTime(), nowMs),
+        commitsSinceSpawn: checkpoint.gitState?.commitsSinceSpawn ?? 0,
+        branch: checkpoint.gitState?.branch ?? session.branch,
+        hasPR: Boolean(session.pr),
+        prNumber: session.pr?.number,
+      },
+      idempotencyKey: createProgressCheckpointIdempotencyKey(session.id, checkpoint.key),
+      timestamp: now,
+    });
+
+    if (reactionConfig.action === "send-to-agent" && reactionConfig.auto !== false) {
+      const message = buildProgressCheckpointAgentMessage(reactionConfig, checkpoint);
+
+      try {
+        await sessionManager.send(session.id, message);
+        logLifecycle("info", "progress_checkpoint.sent_to_agent", {
+          pollId: pollStats?.pollId,
+          projectId: session.projectId,
+          sessionId: session.id,
+          checkpoint: checkpoint.key,
+          missCount,
+        });
+        return;
+      } catch (error) {
+        incrementPollError(pollStats);
+        logLifecycle("error", "progress_checkpoint.send_to_agent.failed", {
+          pollId: pollStats?.pollId,
+          projectId: session.projectId,
+          sessionId: session.id,
+          checkpoint: checkpoint.key,
+          missCount,
+          error,
+        });
+      }
+    }
+
+    await notifyHuman(event, priority, pollStats);
+  }
+
+  async function maybeFireProgressCheckpoint(
+    session: Session,
+    pollStats?: LifecyclePollStats,
+  ): Promise<void> {
+    if (isOrchestratorSession(session)) {
+      return;
+    }
+
+    if (INACTIVE_SESSION_STATUSES.has(getEffectiveSessionStatus(session))) {
+      return;
+    }
+
+    const reactionConfig = getProgressCheckpointConfigForSession(session);
+    if (!reactionConfig) {
+      return;
+    }
+
+    const nowMs = Date.now();
+    const checkpointAgeMs = nowMs - resolveProgressCheckpointBaseAtMs(session);
+    const candidates: ProgressCheckpointCandidate[] = [];
+    let gitState: ProgressGitState | null = null;
+
+    const firstCommitThreshold =
+      typeof reactionConfig.firstCommit === "string" ? reactionConfig.firstCommit : null;
+    const firstPrThreshold =
+      typeof reactionConfig.firstPR === "string" ? reactionConfig.firstPR : null;
+    const firstCommitMs = firstCommitThreshold ? parseDuration(firstCommitThreshold) : 0;
+    const firstPrMs = firstPrThreshold ? parseDuration(firstPrThreshold) : 0;
+
+    if (
+      firstCommitMs > 0 &&
+      checkpointAgeMs >= firstCommitMs &&
+      !session.pr &&
+      !session.metadata[PROGRESS_CHECKPOINT_FIRED_AT_METADATA_KEYS.firstCommit]
+    ) {
+      gitState = await collectGitState(session, nowMs);
+      if (gitState.commitsSinceSpawn === 0) {
+        candidates.push({
+          key: "firstCommit",
+          threshold: firstCommitThreshold ?? "",
+          thresholdMs: firstCommitMs,
+          gitState,
+        });
+      }
+    }
+
+    if (
+      firstPrMs > 0 &&
+      checkpointAgeMs >= firstPrMs &&
+      !session.pr &&
+      !session.metadata[PROGRESS_CHECKPOINT_FIRED_AT_METADATA_KEYS.firstPR]
+    ) {
+      candidates.push({
+        key: "firstPR",
+        threshold: firstPrThreshold ?? "",
+        thresholdMs: firstPrMs,
+        gitState,
+      });
+    }
+
+    if (candidates.length === 0) {
+      return;
+    }
+
+    candidates.sort((left, right) => {
+      if (left.thresholdMs !== right.thresholdMs) {
+        return left.thresholdMs - right.thresholdMs;
+      }
+
+      if (left.key === right.key) {
+        return 0;
+      }
+
+      return left.key === "firstCommit" ? -1 : 1;
+    });
+
+    await fireProgressCheckpoint(session, reactionConfig, candidates[0], pollStats);
+  }
+
   function updateSessionMetadata(session: Session, updates: Partial<Record<string, string>>): void {
     const project = config.projects[session.projectId];
     if (!project) return;
@@ -3133,6 +3391,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     if (newStatus === oldStatus) {
       await maybeRefirePersistentReaction(session, newStatus, pollStats);
     }
+
+    await maybeFireProgressCheckpoint(session, pollStats);
 
     await maybeRecoverOrphanedPR(session, newStatus, pollStats);
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -977,6 +977,15 @@ export interface ReactionConfig {
   /** Maximum session age before agent-stuck fires when no PR exists (e.g. "30m") */
   maxRuntime?: string;
 
+  /** Progress checkpoint threshold for the first pushed commit (e.g. "15m") */
+  firstCommit?: string;
+
+  /** Progress checkpoint threshold for the first opened PR (e.g. "45m") */
+  firstPR?: string;
+
+  /** Optional custom nudge text for progress-checkpoint send-to-agent reactions */
+  checkpointMessage?: string;
+
   /** Whether to include a summary in the notification */
   includeSummary?: boolean;
 }
@@ -1335,6 +1344,10 @@ export interface SessionMetadata {
   opencodeSessionId?: string;
   lastProgressSnapshotAt?: string;
   progressSnapshotCount?: string;
+  progressCheckpointResetAt?: string;
+  progressCheckpointMissCount?: string;
+  progressCheckpointFirstCommitFiredAt?: string;
+  progressCheckpointFirstPRFiredAt?: string;
 }
 
 // =============================================================================

--- a/syntese.yaml.example
+++ b/syntese.yaml.example
@@ -140,6 +140,13 @@ projects:
 #     action: send-to-agent
 #     escalateAfter: 30m
 #
+#   progress-checkpoints:
+#     firstCommit: 15m
+#     firstPR: 45m
+#     action: send-to-agent
+#     priority: warning
+#     checkpointMessage: Please push your current progress and open a draft PR.
+#
 #   approved-and-green:
 #     auto: false
 #     action: notify           # set to auto-merge for automatic merging


### PR DESCRIPTION
## Summary
- add configurable `progress-checkpoints` reaction thresholds for first commit and first PR
- fire one checkpoint nudge per milestone, escalate the second miss to urgent, and persist checkpoint metadata
- reset checkpoint timing on manual `syn send` and document the new config

## Testing
- pnpm run typecheck
- pnpm test
- pnpm run lint

Closes #73