### PR TITLE
feat: add no-commit timeout alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ reactions:
   approved-and-green:
     auto: false
     action: notify
+  agent-stuck:
+    threshold: 10m
+    noCommitTimeout: 20m
+    action: notify
+    priority: urgent
 ```
 
 CI fails → agent gets the logs and fixes it. Reviewer requests changes → agent addresses them. PR approved with green CI → you get a notification to merge.

--- a/SETUP.md
+++ b/SETUP.md
@@ -269,6 +269,7 @@ reactions:
 reactions:
   agent-stuck:
     threshold: 10m # Consider stuck after 10 minutes of inactivity
+    noCommitTimeout: 20m # Escalate if nothing has been pushed after 20 minutes
     action: notify
     priority: urgent
 ```

--- a/examples/auto-merge.yaml
+++ b/examples/auto-merge.yaml
@@ -36,5 +36,6 @@ reactions:
   # Notify when agent is stuck
   agent-stuck:
     threshold: 10m
+    noCommitTimeout: 20m
     action: notify
     priority: urgent

--- a/packages/cli/__tests__/commands/send.test.ts
+++ b/packages/cli/__tests__/commands/send.test.ts
@@ -320,7 +320,9 @@ describe("send command", () => {
 
       await program.parseAsync(["node", "test", "send", "app-1", "hello", "opencode"]);
 
-      expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "hello opencode");
+      expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "hello opencode", {
+        resetNoCommitTimeout: true,
+      });
       expect(mockExec).not.toHaveBeenCalledWith(
         "tmux",
         expect.arrayContaining(["send-keys", "-l", "hello opencode"]),
@@ -356,7 +358,9 @@ describe("send command", () => {
 
       await program.parseAsync(["node", "test", "send", "app-1", "fix", "mapping"]);
 
-      expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "fix mapping");
+      expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "fix mapping", {
+        resetNoCommitTimeout: true,
+      });
       expect(consoleSpy).not.toHaveBeenCalledWith(
         expect.stringContaining("Waiting for app-1 to become idle"),
       );
@@ -391,7 +395,9 @@ describe("send command", () => {
 
       await program.parseAsync(["node", "test", "send", "app-1", "hello"]);
 
-      expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "hello");
+      expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "hello", {
+        resetNoCommitTimeout: true,
+      });
       expect(mockTmux).not.toHaveBeenCalledWith("has-session", "-t", expect.any(String));
     });
 
@@ -428,7 +434,9 @@ describe("send command", () => {
         rmSync(filePath, { force: true });
       }
 
-      expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "from file");
+      expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "from file", {
+        resetNoCommitTimeout: true,
+      });
     });
   });
 });

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -183,7 +183,7 @@ export function registerSend(program: Command): void {
         }
 
         if (existingSession && sessionManager) {
-          await sessionManager.send(session, message);
+          await sessionManager.send(session, message, { resetNoCommitTimeout: true });
           console.log(chalk.green("Message sent and processing"));
           return;
         }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -71,7 +71,7 @@ spawning → working → completed
 - `ci-failed` → send fix prompt to agent
 - `changes-requested` → send review comments to agent
 - `approved-and-green` → notify human (or auto-merge)
-- `agent-stuck` → notify human
+- `agent-stuck` → notify human after prolonged idle time or no pushed commits
 
 **Polling loop:**
 

--- a/packages/core/__tests__/config.test.ts
+++ b/packages/core/__tests__/config.test.ts
@@ -158,6 +158,29 @@ reactions:
       );
     });
 
+    it("includes a default noCommitTimeout on agent-stuck", () => {
+      const configPath = join(testDir, "default-stuck-config.yaml");
+      writeFileSync(
+        configPath,
+        `
+projects:
+  test-project:
+    repo: test/repo
+    path: ${testDir}
+    defaultBranch: main
+`,
+      );
+
+      const config = loadConfig(configPath);
+
+      expect(config.reactions["agent-stuck"]).toEqual(
+        expect.objectContaining({
+          threshold: "10m",
+          noCommitTimeout: "20m",
+        }),
+      );
+    });
+
     it("parses progressChecks config and normalizes notify to an array", () => {
       const configPath = join(testDir, "progress-config.yaml");
 

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -102,6 +102,12 @@ function createCommittedRepo(repoPath: string, files: Record<string, string> = {
   return repoPath;
 }
 
+function createBareRemoteRepo(remotePath: string): string {
+  mkdirSync(remotePath, { recursive: true });
+  runGit(remotePath, "init", "--bare");
+  return remotePath;
+}
+
 function computeEventIdempotencyKey(
   sessionId: string,
   transition: string,
@@ -896,6 +902,175 @@ describe("check (single session)", () => {
       "session.completed",
       "reaction.triggered",
     ]);
+  });
+
+  it("marks sessions stuck after noCommitTimeout when commits exist only locally", async () => {
+    config.reactions["agent-stuck"] = {
+      auto: false,
+      action: "notify",
+      threshold: "1h",
+      noCommitTimeout: "5m",
+    };
+
+    const remotePath = createBareRemoteRepo(join(tmpDir, "remote.git"));
+    const repoPath = createCommittedRepo(join(tmpDir, "repo-local-only"));
+    runGit(repoPath, "remote", "add", "origin", remotePath);
+    runGit(repoPath, "push", "-u", "origin", "main");
+    runGit(repoPath, "checkout", "-b", "feat/local-only");
+    writeRepoFile(repoPath, "src/local.txt", "visible only locally\n");
+    runGit(repoPath, "add", "src/local.txt");
+    runGit(repoPath, "commit", "-m", "local only");
+
+    const createdAt = new Date(Date.now() - 10 * 60_000);
+    const session = makeSession({
+      status: "working",
+      branch: "feat/local-only",
+      workspacePath: repoPath,
+      createdAt,
+      metadata: {
+        status: "working",
+        project: "my-app",
+        branch: "feat/local-only",
+        agent: "mock-agent",
+        createdAt: createdAt.toISOString(),
+      },
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: repoPath,
+      branch: "feat/local-only",
+      status: "working",
+      project: "my-app",
+      agent: "mock-agent",
+      createdAt: createdAt.toISOString(),
+      runtimeHandle: JSON.stringify(session.runtimeHandle),
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("stuck");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("stuck");
+  });
+
+  it("respects a reset no-commit window after steering", async () => {
+    config.reactions["agent-stuck"] = {
+      auto: false,
+      action: "notify",
+      threshold: "1h",
+      noCommitTimeout: "5m",
+    };
+
+    const remotePath = createBareRemoteRepo(join(tmpDir, "remote-steering.git"));
+    const repoPath = createCommittedRepo(join(tmpDir, "repo-steering"));
+    runGit(repoPath, "remote", "add", "origin", remotePath);
+    runGit(repoPath, "push", "-u", "origin", "main");
+    runGit(repoPath, "checkout", "-b", "feat/steered");
+
+    const createdAt = new Date(Date.now() - 10 * 60_000);
+    const noCommitWindowStartedAt = new Date(Date.now() - 60_000).toISOString();
+    const session = makeSession({
+      status: "working",
+      branch: "feat/steered",
+      workspacePath: repoPath,
+      createdAt,
+      metadata: {
+        status: "working",
+        project: "my-app",
+        branch: "feat/steered",
+        agent: "mock-agent",
+        createdAt: createdAt.toISOString(),
+        noCommitWindowStartedAt,
+      },
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: repoPath,
+      branch: "feat/steered",
+      status: "working",
+      project: "my-app",
+      agent: "mock-agent",
+      createdAt: createdAt.toISOString(),
+      noCommitWindowStartedAt,
+      runtimeHandle: JSON.stringify(session.runtimeHandle),
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("working");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("working");
+  });
+
+  it("records first pushed commit and skips noCommitTimeout after a push", async () => {
+    config.reactions["agent-stuck"] = {
+      auto: false,
+      action: "notify",
+      threshold: "1h",
+      noCommitTimeout: "5m",
+    };
+
+    const remotePath = createBareRemoteRepo(join(tmpDir, "remote-pushed.git"));
+    const repoPath = createCommittedRepo(join(tmpDir, "repo-pushed"));
+    runGit(repoPath, "remote", "add", "origin", remotePath);
+    runGit(repoPath, "push", "-u", "origin", "main");
+    runGit(repoPath, "checkout", "-b", "feat/pushed");
+
+    const createdAt = new Date(Date.now() - 10 * 60_000);
+    writeRepoFile(repoPath, "src/pushed.txt", "visible on remote\n");
+    runGit(repoPath, "add", "src/pushed.txt");
+    runGit(repoPath, "commit", "-m", "push it");
+    runGit(repoPath, "push", "-u", "origin", "feat/pushed");
+
+    const session = makeSession({
+      status: "working",
+      branch: "feat/pushed",
+      workspacePath: repoPath,
+      createdAt,
+      metadata: {
+        status: "working",
+        project: "my-app",
+        branch: "feat/pushed",
+        agent: "mock-agent",
+        createdAt: createdAt.toISOString(),
+      },
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: repoPath,
+      branch: "feat/pushed",
+      status: "working",
+      project: "my-app",
+      agent: "mock-agent",
+      createdAt: createdAt.toISOString(),
+      runtimeHandle: JSON.stringify(session.runtimeHandle),
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(lm.getStates().get("app-1")).toBe("working");
+    expect(metadata?.["status"]).toBe("working");
+    expect(metadata?.["firstPushedCommitAt"]).toBeDefined();
   });
 
   it("stays working when agent is idle but process is still running (fallback path)", async () => {

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -2189,6 +2189,24 @@ describe("send", () => {
     expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("working");
   });
 
+  it("resets the no-commit timer when requested", async () => {
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+    vi.mocked(mockRuntime.getOutput).mockResolvedValueOnce("before").mockResolvedValueOnce("after");
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await sm.send("app-1", "Keep going", { resetNoCommitTimeout: true });
+
+    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["status"]).toBe("working");
+    expect(metadata?.["noCommitWindowStartedAt"]).toBeDefined();
+  });
+
   it("prefers a live session over stale terminal metadata when sending", async () => {
     writeMetadata(sessionsDir, "app-1", {
       worktree: "/tmp",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -80,6 +80,7 @@ const ReactionConfigSchema = z.object({
   refireIntervalMs: z.number().nonnegative().optional(),
   escalateAfter: z.union([z.number(), z.string()]).optional(),
   threshold: z.string().optional(),
+  noCommitTimeout: z.string().optional(),
   includeSummary: z.boolean().optional(),
 });
 
@@ -407,6 +408,7 @@ function applyDefaultReactions(config: OrchestratorConfig): OrchestratorConfig {
       priority: "urgent",
       refireIntervalMs: 300_000,
       threshold: "10m",
+      noCommitTimeout: "20m",
     },
     "agent-needs-input": {
       auto: true,

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -644,6 +644,43 @@ function parseDirtyFiles(output: string | null): string[] {
     });
 }
 
+function parseRemoteBranchRefs(output: string | null): string[] {
+  if (!output) return [];
+
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => Boolean(line) && !line.includes("->"));
+}
+
+function matchesRemoteBranch(branch: string | null, ref: string | null): boolean {
+  if (!branch || !ref) return false;
+  return ref === branch || ref.endsWith(`/${branch}`);
+}
+
+async function resolvePushedBranchRef(
+  workspacePath: string,
+  branch: string | null,
+): Promise<string | null> {
+  const upstreamOutput = await runGitProgressCommand(
+    ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+    workspacePath,
+  );
+  const upstreamRef = upstreamOutput?.trim() || null;
+  if (matchesRemoteBranch(branch, upstreamRef)) {
+    return upstreamRef;
+  }
+
+  if (!branch) {
+    return null;
+  }
+
+  const remoteBranches = parseRemoteBranchRefs(
+    await runGitProgressCommand(["branch", "-r", "--list", `*/${branch}`], workspacePath),
+  );
+  return remoteBranches.length === 1 ? remoteBranches[0] : null;
+}
+
 async function collectGitState(session: Session, nowMs: number): Promise<ProgressGitState> {
   const workspacePath = session.workspacePath;
   if (!workspacePath) {
@@ -657,25 +694,24 @@ async function collectGitState(session: Session, nowMs: number): Promise<Progres
   }
 
   const createdAtIso = session.createdAt.toISOString();
-  const [branchOutput, commitCountOutput, lastCommitOutput, dirtyOutput, upstreamOutput] =
-    await Promise.all([
-      runGitProgressCommand(["branch", "--show-current"], workspacePath),
-      runGitProgressCommand(
-        ["rev-list", "--count", `--since=${createdAtIso}`, "HEAD"],
-        workspacePath,
-      ),
-      runGitProgressCommand(["log", "-1", "--format=%ct"], workspacePath),
-      runGitProgressCommand(["status", "--porcelain", "--untracked-files=all"], workspacePath),
-      runGitProgressCommand(
-        ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
-        workspacePath,
-      ),
-    ]);
+  const branchOutput = await runGitProgressCommand(["branch", "--show-current"], workspacePath);
+  const branch = branchOutput?.trim() || session.branch;
+  const pushedBranchRef = await resolvePushedBranchRef(workspacePath, branch);
+  const [commitCountOutput, lastCommitOutput, dirtyOutput] = await Promise.all([
+    pushedBranchRef
+      ? runGitProgressCommand(
+          ["rev-list", "--count", `--since=${createdAtIso}`, pushedBranchRef],
+          workspacePath,
+        )
+      : Promise.resolve("0"),
+    runGitProgressCommand(["log", "-1", "--format=%ct"], workspacePath),
+    runGitProgressCommand(["status", "--porcelain", "--untracked-files=all"], workspacePath),
+  ]);
 
   const lastCommitSeconds = lastCommitOutput ? Number.parseInt(lastCommitOutput, 10) : Number.NaN;
 
   return {
-    branch: branchOutput?.trim() || session.branch,
+    branch,
     commitsSinceSpawn: commitCountOutput
       ? Math.max(0, Number.parseInt(commitCountOutput, 10) || 0)
       : 0,
@@ -683,7 +719,7 @@ async function collectGitState(session: Session, nowMs: number): Promise<Progres
       ? toElapsedMinutes(lastCommitSeconds * 1000, nowMs)
       : null,
     dirtyFiles: parseDirtyFiles(dirtyOutput),
-    hasPushed: Boolean(upstreamOutput?.trim()) || Boolean(session.pr),
+    hasPushed: Boolean(pushedBranchRef) || Boolean(session.pr),
   };
 }
 
@@ -1547,17 +1583,65 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
   }
 
+  function getAgentStuckDurationMs(
+    session: Session,
+    field: "threshold" | "noCommitTimeout",
+  ): number | null {
+    const stuckReaction = getReactionConfigForSession(session, "agent-stuck");
+    const duration = stuckReaction?.[field];
+    if (typeof duration !== "string") return null;
+
+    const durationMs = parseDuration(duration);
+    return durationMs > 0 ? durationMs : null;
+  }
+
   /** Check if idle time exceeds the agent-stuck threshold. */
   function isIdleBeyondThreshold(session: Session, idleTimestamp: Date): boolean {
-    const stuckReaction =
-      config.projects[session.projectId]?.reactions?.["agent-stuck"] ??
-      config.reactions["agent-stuck"];
-    const thresholdStr = (stuckReaction as Record<string, unknown> | undefined)?.threshold;
-    if (typeof thresholdStr !== "string") return false;
-    const stuckThresholdMs = parseDuration(thresholdStr);
-    if (stuckThresholdMs <= 0) return false;
+    const stuckThresholdMs = getAgentStuckDurationMs(session, "threshold");
+    if (stuckThresholdMs === null) return false;
     const idleMs = Date.now() - idleTimestamp.getTime();
     return idleMs > stuckThresholdMs;
+  }
+
+  function getNoCommitWindowStartedAtMs(session: Session): number {
+    return parseTimestampMs(session.metadata["noCommitWindowStartedAt"]) ?? session.createdAt.getTime();
+  }
+
+  function shouldApplyNoCommitTimeoutToStatus(status: SessionStatus): boolean {
+    return (
+      status === SESSION_STATUS.SPAWNING ||
+      status === SESSION_STATUS.WORKING ||
+      status === SESSION_STATUS.COMPLETED ||
+      status === SESSION_STATUS.STUCK ||
+      status === SESSION_STATUS.PR_OPEN ||
+      status === SESSION_STATUS.REVIEW_PENDING ||
+      status === SESSION_STATUS.APPROVED
+    );
+  }
+
+  async function isNoCommitBeyondThreshold(session: Session, nowMs: number): Promise<boolean> {
+    if (!session.workspacePath) {
+      return false;
+    }
+
+    const noCommitTimeoutMs = getAgentStuckDurationMs(session, "noCommitTimeout");
+    if (noCommitTimeoutMs === null) {
+      return false;
+    }
+
+    if (parseTimestampMs(session.metadata["firstPushedCommitAt"]) !== null) {
+      return false;
+    }
+
+    const gitState = await collectGitState(session, nowMs);
+    if (gitState.commitsSinceSpawn > 0) {
+      updateSessionMetadata(session, {
+        firstPushedCommitAt: session.metadata["firstPushedCommitAt"] ?? new Date(nowMs).toISOString(),
+      });
+      return false;
+    }
+
+    return nowMs - getNoCommitWindowStartedAtMs(session) > noCommitTimeoutMs;
   }
 
   async function evaluateOpenPR(
@@ -1647,6 +1731,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     ) {
       return SESSION_STATUS.DONE;
     }
+
+    const nowMs = Date.now();
 
     const project = config.projects[session.projectId];
     if (!project) return currentStatus;
@@ -1798,6 +1884,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       }
     }
 
+    const noCommitTimedOut = await isNoCommitBeyondThreshold(session, nowMs);
+
     // 4. Check PR state if PR exists
     if (session.pr && scm) {
       let verificationEvaluation = await evaluatePostPushVerification(session, project);
@@ -1839,6 +1927,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           return SESSION_STATUS.APPROVED;
         }
 
+        if (noCommitTimedOut && shouldApplyNoCommitTimeoutToStatus(currentStatus)) {
+          return SESSION_STATUS.STUCK;
+        }
+
         if (
           detectedIdleTimestamp &&
           isIdleBeyondThreshold(session, detectedIdleTimestamp) &&
@@ -1871,6 +1963,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
         if (preserveCurrentStatus) {
           return currentStatus;
+        }
+
+        if (
+          noCommitTimedOut &&
+          shouldApplyNoCommitTimeoutToStatus(openPREvaluation.status)
+        ) {
+          return SESSION_STATUS.STUCK;
         }
 
         if (openPREvaluation.status === SESSION_STATUS.APPROVED) {
@@ -1913,6 +2012,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     if (preserveCurrentStatus) {
       return currentStatus;
+    }
+
+    if (noCommitTimedOut && shouldApplyNoCommitTimeoutToStatus(currentStatus)) {
+      return SESSION_STATUS.STUCK;
     }
 
     // 5. Agents can finish a turn without exiting. When they become ready/idle and

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -27,6 +27,7 @@ import {
   type Session,
   type SessionId,
   type SessionSpawnConfig,
+  type SessionSendOptions,
   type OrchestratorSpawnConfig,
   type CleanupResult,
   type ClaimPROptions,
@@ -2086,7 +2087,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     return result;
   }
 
-  async function send(sessionId: SessionId, message: string): Promise<void> {
+  async function send(
+    sessionId: SessionId,
+    message: string,
+    options?: SessionSendOptions,
+  ): Promise<void> {
     const { raw, sessionsDir, project } = requireSessionRecord(sessionId);
     const persistedStatus = validateStatus(raw["status"]);
     const pause = getProjectPause(project);
@@ -2299,8 +2304,18 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     // A freshly delivered prompt means the session is actively working again,
     // even if the last persisted status was idle/stuck/review-related.
+    const metadataUpdates: Record<string, string> = {};
+
     if (!NON_RESTORABLE_STATUSES.has(persistedStatus)) {
-      updateMetadata(sessionsDir, sessionId, { status: "working" });
+      metadataUpdates["status"] = "working";
+    }
+
+    if (options?.resetNoCommitTimeout) {
+      metadataUpdates["noCommitWindowStartedAt"] = new Date().toISOString();
+    }
+
+    if (Object.keys(metadataUpdates).length > 0) {
+      updateMetadata(sessionsDir, sessionId, metadataUpdates);
     }
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -974,6 +974,9 @@ export interface ReactionConfig {
   /** Threshold duration for time-based triggers (e.g. "10m" for stuck detection) */
   threshold?: string;
 
+  /** Threshold duration for escalating sessions with no pushed commits since spawn */
+  noCommitTimeout?: string;
+
   /** Whether to include a summary in the notification */
   includeSummary?: boolean;
 }
@@ -1332,11 +1335,18 @@ export interface SessionMetadata {
   opencodeSessionId?: string;
   lastProgressSnapshotAt?: string;
   progressSnapshotCount?: string;
+  noCommitWindowStartedAt?: string;
+  firstPushedCommitAt?: string;
 }
 
 // =============================================================================
 // SERVICE INTERFACES (core, not pluggable)
 // =============================================================================
+
+export interface SessionSendOptions {
+  /** Reset the no-commit timeout window after manual steering. */
+  resetNoCommitTimeout?: boolean;
+}
 
 /** Session manager — CRUD for sessions */
 export interface SessionManager {
@@ -1350,7 +1360,7 @@ export interface SessionManager {
     projectId?: string,
     options?: { dryRun?: boolean; purgeOpenCode?: boolean },
   ): Promise<CleanupResult>;
-  send(sessionId: SessionId, message: string): Promise<void>;
+  send(sessionId: SessionId, message: string, options?: SessionSendOptions): Promise<void>;
   claimPR(sessionId: SessionId, prRef: string, options?: ClaimPROptions): Promise<ClaimPRResult>;
 }
 

--- a/syntese.yaml.example
+++ b/syntese.yaml.example
@@ -147,5 +147,6 @@ projects:
 #
 #   agent-stuck:
 #     threshold: 10m
+#     noCommitTimeout: 20m
 #     action: notify
 #     priority: urgent


### PR DESCRIPTION
## Summary
- add `reactions.agent-stuck.noCommitTimeout` with a 20-minute default
- mark sessions as stuck when they exceed the no-commit window without any pushed commits
- reset the window on manual `ao send`, persist the first pushed commit, and update tests/docs

## Testing
- pnpm build
- pnpm run typecheck
- pnpm test
- pnpm run lint

Closes #72