### PR TITLE
feat: add account registry and auth isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,20 @@ defaults:
   workspace: worktree
   notifiers: [desktop]
 
+agentPool:
+  accounts:
+    - id: codex-pro-1
+      agent: codex
+      model: gpt-5.4-xhigh
+      auth:
+        profile: personal-codex
+      limits:
+        quotaWindow: 5h
+        overageType: credits
+        overageEnabled: true
+        overageSpendCap: 50
+        apiKeyFallback: true
+
 projects:
   my-app:
     repo: owner/my-app
@@ -164,6 +178,8 @@ CI fails → agent gets the logs and fixes it. Reviewers request changes → age
 
 If a project needs live verification beyond CI, `verification.postPush` runs a project-defined command after each new pushed `HEAD`. `block-merge` prevents auto-merge and the dashboard merge action until that verification passes.
 
+Use `agentPool.accounts` when you need multiple subscriptions per agent type with isolated auth. Syntese stores each account under `~/.syntese/accounts/<id>/` and injects the matching CLI auth directory into each spawned session.
+
 See [`syntese.yaml.example`](syntese.yaml.example) for the full reference.
 
 ## CLI
@@ -171,6 +187,11 @@ See [`syntese.yaml.example`](syntese.yaml.example) for the full reference.
 ```bash
 syn status                              # Overview of all sessions
 syn spawn <project> [issue]             # Spawn an agent
+syn spawn <project> [issue] --account <id> # Spawn with isolated account auth
+syn accounts                            # List configured + implicit accounts
+syn accounts test <id>                  # Verify auth for one account
+syn accounts login <id>                 # Run account-specific login flow
+syn accounts status                     # Show which sessions use which account
 syn send <session> "Fix the tests"      # Send instructions
 syn session ls                          # List sessions
 syn session kill <session>              # Kill a session

--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -312,6 +312,36 @@ describe("spawn command", () => {
     });
   });
 
+  it("passes --account flag to sessionManager.spawn()", async () => {
+    const fakeSession: Session = {
+      id: "app-1",
+      projectId: "my-app",
+      status: "spawning",
+      activity: null,
+      branch: null,
+      issueId: null,
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "hash-app-1", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: { accountId: "codex-pro-1" },
+    };
+
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    await program.parseAsync(["node", "test", "spawn", "my-app", "--account", "codex-pro-1"]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "my-app",
+        issueId: undefined,
+        account: "codex-pro-1",
+      }),
+    );
+  });
+
   it("rejects unknown project ID", async () => {
     await expect(program.parseAsync(["node", "test", "spawn", "nonexistent"])).rejects.toThrow(
       "process.exit(1)",

--- a/packages/cli/src/commands/accounts.ts
+++ b/packages/cli/src/commands/accounts.ts
@@ -1,0 +1,334 @@
+import chalk from "chalk";
+import type { Command } from "commander";
+import {
+  getAccountDataDir,
+  getEffectiveAccounts,
+  loadConfig,
+  type AccountConfig,
+  type OrchestratorConfig,
+  type Session,
+  PRIMARY_CLI_COMMAND,
+} from "@syntese/core";
+import { banner, padCol } from "../lib/format.js";
+import { getSessionManager } from "../lib/create-session-manager.js";
+import { loginAccount, resolveSessionAccountId, testAccountAuth } from "../lib/accounts.js";
+
+const ACTIVE_SESSION_STATUSES = new Set(["working", "spawning", "ready", "idle"]);
+
+const COL = {
+  account: 18,
+  agent: 14,
+  profile: 18,
+  source: 10,
+  auth: 20,
+  sessions: 10,
+};
+
+interface AccountRow {
+  accountId: string;
+  account: AccountConfig;
+  authSummary: string;
+  authOk: boolean;
+  activeSessions: number;
+  source: "config" | "implicit";
+}
+
+function formatAuth(authOk: boolean, summary: string): string {
+  if (authOk) {
+    return chalk.green(summary);
+  }
+  return chalk.yellow(summary);
+}
+
+function printAccountsHeader(): void {
+  const header =
+    padCol("Account", COL.account) +
+    padCol("Agent", COL.agent) +
+    padCol("Profile", COL.profile) +
+    padCol("Source", COL.source) +
+    padCol("Auth", COL.auth) +
+    "Sessions";
+  console.log(chalk.dim(`  ${header}`));
+  console.log(chalk.dim(`  ${"─".repeat(COL.account + COL.agent + COL.profile + COL.source + COL.auth + COL.sessions + 2)}`));
+}
+
+function printAccountRow(row: AccountRow): void {
+  const profile = row.account.auth?.profile ?? "—";
+  const line =
+    padCol(chalk.cyan(row.accountId), COL.account) +
+    padCol(chalk.dim(row.account.agent), COL.agent) +
+    padCol(profile, COL.profile) +
+    padCol(chalk.dim(row.source), COL.source) +
+    padCol(formatAuth(row.authOk, row.authSummary), COL.auth) +
+    String(row.activeSessions);
+  console.log(`  ${line}`);
+}
+
+function requireAccount(
+  config: OrchestratorConfig,
+  accountId: string,
+): { accountId: string; account: AccountConfig; source: "config" | "implicit" } {
+  const accounts = getEffectiveAccounts(config);
+  const account = accounts[accountId];
+  if (!account) {
+    throw new Error(
+      `Unknown account: ${accountId}\nAvailable: ${Object.keys(accounts).sort().join(", ") || "(none)"}`,
+    );
+  }
+
+  return {
+    accountId,
+    account,
+    source: config.accounts?.[accountId] ? "config" : "implicit",
+  };
+}
+
+async function getActiveSessionsByAccount(
+  config: OrchestratorConfig,
+): Promise<Map<string, Session[]>> {
+  const sessionsByAccount = new Map<string, Session[]>();
+
+  try {
+    const sessionManager = await getSessionManager(config);
+    const sessions = await sessionManager.list();
+    for (const session of sessions) {
+      if (!ACTIVE_SESSION_STATUSES.has(session.status)) {
+        continue;
+      }
+
+      const accountId = resolveSessionAccountId(config, session);
+      const existing = sessionsByAccount.get(accountId) ?? [];
+      existing.push(session);
+      sessionsByAccount.set(accountId, existing);
+    }
+  } catch {
+    // Best effort — account commands should still work without session metadata access.
+  }
+
+  return sessionsByAccount;
+}
+
+async function listAccounts(opts: { json?: boolean } = {}): Promise<void> {
+  const config = loadConfig();
+  const accounts = getEffectiveAccounts(config);
+  const activeSessionsByAccount = await getActiveSessionsByAccount(config);
+  const rows = await Promise.all(
+    Object.entries(accounts).map(async ([accountId, account]) => {
+      const auth = await testAccountAuth(accountId, account);
+      return {
+        accountId,
+        account,
+        authSummary: auth.summary,
+        authOk: auth.ok,
+        activeSessions: activeSessionsByAccount.get(accountId)?.length ?? 0,
+        source: config.accounts?.[accountId] ? "config" : "implicit",
+      } satisfies AccountRow;
+    }),
+  );
+
+  rows.sort((left, right) => left.accountId.localeCompare(right.accountId));
+
+  if (opts.json) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
+  console.log(banner("SYNTESE ACCOUNTS"));
+  console.log();
+
+  if (rows.length === 0) {
+    console.log(chalk.dim("  No accounts found."));
+    console.log();
+    return;
+  }
+
+  printAccountsHeader();
+  for (const row of rows) {
+    printAccountRow(row);
+  }
+  console.log();
+}
+
+async function runAccountTest(accountId: string, opts: { json?: boolean } = {}): Promise<void> {
+  const config = loadConfig();
+  const resolved = requireAccount(config, accountId);
+  const auth = await testAccountAuth(resolved.accountId, resolved.account);
+  const payload = {
+    accountId: resolved.accountId,
+    agent: resolved.account.agent,
+    profile: resolved.account.auth?.profile ?? null,
+    accountDir: getAccountDataDir(resolved.accountId),
+    authenticated: auth.ok,
+    summary: auth.summary,
+    details: auth.details ?? null,
+  };
+
+  if (opts.json) {
+    console.log(JSON.stringify(payload, null, 2));
+    if (!auth.ok) {
+      process.exit(1);
+    }
+    return;
+  }
+
+  console.log(banner("ACCOUNT TEST"));
+  console.log();
+  console.log(`  Account: ${chalk.cyan(resolved.accountId)}`);
+  console.log(`  Agent:   ${chalk.dim(resolved.account.agent)}`);
+  console.log(`  Profile: ${chalk.dim(resolved.account.auth?.profile ?? "—")}`);
+  console.log(`  Dir:     ${chalk.dim(getAccountDataDir(resolved.accountId))}`);
+  console.log(`  Auth:    ${auth.ok ? chalk.green(auth.summary) : chalk.yellow(auth.summary)}`);
+  console.log();
+
+  if (!auth.ok) {
+    process.exit(1);
+  }
+}
+
+async function runAccountLogin(accountId: string): Promise<void> {
+  const config = loadConfig();
+  const resolved = requireAccount(config, accountId);
+
+  console.log(banner("ACCOUNT LOGIN"));
+  console.log();
+  console.log(`  Account: ${chalk.cyan(resolved.accountId)}`);
+  console.log(`  Agent:   ${chalk.dim(resolved.account.agent)}`);
+  console.log(`  Profile: ${chalk.dim(resolved.account.auth?.profile ?? "—")}`);
+  console.log(`  Dir:     ${chalk.dim(getAccountDataDir(resolved.accountId))}`);
+  console.log();
+
+  const exitCode = await loginAccount(resolved.accountId, resolved.account);
+  if (exitCode !== 0) {
+    process.exit(exitCode);
+  }
+
+  const auth = await testAccountAuth(resolved.accountId, resolved.account);
+  console.log();
+  console.log(
+    auth.ok
+      ? chalk.green(`✓ ${resolved.accountId} authenticated (${auth.summary})`)
+      : chalk.yellow(
+          `! ${resolved.accountId} login completed, but auth check still reports: ${auth.summary}`,
+        ),
+  );
+  console.log();
+
+  if (!auth.ok) {
+    process.exit(1);
+  }
+}
+
+async function showAccountSessionStatus(opts: { json?: boolean } = {}): Promise<void> {
+  const config = loadConfig();
+  const activeSessionsByAccount = await getActiveSessionsByAccount(config);
+  const rows = [...activeSessionsByAccount.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([accountId, sessions]) => {
+      const explicitAccount = config.accounts?.[accountId] ?? null;
+      return {
+        accountId,
+        agent:
+          explicitAccount?.agent ??
+          sessions[0]?.metadata["agent"] ??
+          config.projects[sessions[0]?.projectId ?? ""]?.agent ??
+          config.defaults.agent,
+        profile: explicitAccount?.auth?.profile ?? null,
+        sessions: sessions
+          .slice()
+          .sort((left, right) => left.id.localeCompare(right.id))
+          .map((session) => ({
+            id: session.id,
+            projectId: session.projectId,
+            status: session.status,
+            issueId: session.issueId,
+            branch: session.branch,
+          })),
+      };
+    });
+
+  if (opts.json) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+
+  console.log(banner("ACCOUNT SESSION STATUS"));
+  console.log();
+
+  if (rows.length === 0) {
+    console.log(chalk.dim("  No active sessions are using tracked accounts."));
+    console.log();
+    return;
+  }
+
+  for (const row of rows) {
+    const profileSuffix = row.profile ? chalk.dim(` (${row.profile})`) : "";
+    console.log(`  ${chalk.cyan(row.accountId)} ${chalk.dim(row.agent)}${profileSuffix}`);
+    for (const session of row.sessions) {
+      const detail = [session.projectId, session.issueId ?? session.branch ?? "—"]
+        .filter(Boolean)
+        .join(" · ");
+      console.log(`    ${session.id}  ${chalk.dim(detail)}  ${chalk.dim(session.status)}`);
+    }
+    console.log();
+  }
+}
+
+export function registerAccounts(program: Command): void {
+  const accountsCommand = program
+    .command("accounts")
+    .description("Manage configured agent accounts")
+    .option("--json", "Output as JSON")
+    .action(async (opts: { json?: boolean }) => {
+      try {
+        await listAccounts(opts);
+      } catch (err) {
+        console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
+        process.exit(1);
+      }
+    });
+
+  accountsCommand
+    .command("test")
+    .description("Test auth for a configured account")
+    .argument("<id>", "Account ID")
+    .option("--json", "Output as JSON")
+    .action(async (accountId: string, opts: { json?: boolean }) => {
+      try {
+        await runAccountTest(accountId, opts);
+      } catch (err) {
+        console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
+        process.exit(1);
+      }
+    });
+
+  accountsCommand
+    .command("login")
+    .description("Run an interactive login flow for an account")
+    .argument("<id>", "Account ID")
+    .action(async (accountId: string) => {
+      try {
+        await runAccountLogin(accountId);
+      } catch (err) {
+        console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
+        process.exit(1);
+      }
+    });
+
+  accountsCommand
+    .command("status")
+    .description("Show which sessions are using which accounts")
+    .option("--json", "Output as JSON")
+    .action(async (opts: { json?: boolean }) => {
+      try {
+        await showAccountSessionStatus(opts);
+      } catch (err) {
+        console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
+        process.exit(1);
+      }
+    });
+
+  accountsCommand.addHelpText(
+    "after",
+    `\nExamples:\n  ${PRIMARY_CLI_COMMAND} accounts\n  ${PRIMARY_CLI_COMMAND} accounts test codex-pro-1\n  ${PRIMARY_CLI_COMMAND} accounts login claude-max-1\n  ${PRIMARY_CLI_COMMAND} accounts status`,
+  );
+}

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -53,6 +53,7 @@ async function spawnSession(
   issueId?: string,
   openTab?: boolean,
   agent?: string,
+  account?: string,
   claimOptions?: SpawnClaimOptions,
 ): Promise<string> {
   const spinner = ora("Creating session").start();
@@ -65,6 +66,7 @@ async function spawnSession(
       projectId,
       issueId,
       agent,
+      account,
     });
 
     let branchStr = session.branch ?? "";
@@ -127,6 +129,7 @@ export function registerSpawn(program: Command): void {
     .argument("[issue]", "Issue identifier (e.g. INT-1234, #42) - must exist in tracker")
     .option("--open", "Open session in terminal tab")
     .option("--agent <name>", "Override the agent plugin (e.g. codex, claude-code)")
+    .option("--account <id>", "Use a specific configured account for this session")
     .option("--claim-pr <pr>", "Immediately claim an existing PR for the spawned session")
     .option("--assign-on-github", "Assign the claimed PR to the authenticated GitHub user")
     .option("--decompose", "Decompose issue into subtasks before spawning")
@@ -138,6 +141,7 @@ export function registerSpawn(program: Command): void {
         opts: {
           open?: boolean;
           agent?: string;
+          account?: string;
           claimPr?: string;
           assignOnGithub?: boolean;
           decompose?: boolean;
@@ -196,7 +200,15 @@ export function registerSpawn(program: Command): void {
 
             if (leaves.length <= 1) {
               console.log(chalk.yellow("Task is atomic — spawning directly."));
-              await spawnSession(config, projectId, issueId, opts.open, opts.agent, claimOptions);
+              await spawnSession(
+                config,
+                projectId,
+                issueId,
+                opts.open,
+                opts.agent,
+                opts.account,
+                claimOptions,
+              );
             } else {
               // Create child issues and spawn sessions with lineage context
               const sm = await getSessionManager(config);
@@ -212,6 +224,7 @@ export function registerSpawn(program: Command): void {
                     lineage: leaf.lineage,
                     siblings,
                     agent: opts.agent,
+                    account: opts.account,
                   });
                   console.log(`  ${chalk.green("✓")} ${session.id} — ${leaf.description}`);
                 } catch (err) {
@@ -223,7 +236,15 @@ export function registerSpawn(program: Command): void {
               }
             }
           } else {
-            await spawnSession(config, projectId, issueId, opts.open, opts.agent, claimOptions);
+            await spawnSession(
+              config,
+              projectId,
+              issueId,
+              opts.open,
+              opts.agent,
+              opts.account,
+              claimOptions,
+            );
           }
         } catch (err) {
           console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
@@ -278,8 +299,14 @@ export function registerBatchSpawn(program: Command): void {
       const existingSessions = await sm.list(projectId);
       const existingIssueMap = new Map(
         existingSessions
-          .filter((s) => s.issueId && !TERMINAL_STATUSES.has(s.status))
-          .map((s) => [s.issueId!.toLowerCase(), s.id]),
+          .filter(
+            (
+              session,
+            ): session is typeof session & {
+              issueId: string;
+            } => Boolean(session.issueId) && !TERMINAL_STATUSES.has(session.status),
+          )
+          .map((session) => [session.issueId.toLowerCase(), session.id]),
       );
 
       for (const issue of issues) {

--- a/packages/cli/src/lib/accounts.ts
+++ b/packages/cli/src/lib/accounts.ts
@@ -1,0 +1,185 @@
+import { execFile as execFileCallback, spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { promisify } from "node:util";
+import {
+  getAccountDataDir,
+  getAccountEnvironment,
+  getAccountLoginCommand,
+  getAccountStatusCommand,
+  resolveAccountForProject,
+  type AccountConfig,
+  type OrchestratorConfig,
+  type Session,
+} from "@syntese/core";
+
+const execFileAsync = promisify(execFileCallback);
+
+export interface AccountAuthCheck {
+  ok: boolean;
+  summary: string;
+  details?: Record<string, unknown>;
+}
+
+interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+function formatExecError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  env: Record<string, string>,
+): Promise<CommandResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync(command, args, {
+      env: { ...process.env, ...env },
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return {
+      exitCode: 0,
+      stdout: stdout.trimEnd(),
+      stderr: stderr.trimEnd(),
+    };
+  } catch (err: unknown) {
+    const stdout =
+      typeof err === "object" && err !== null && "stdout" in err && typeof err.stdout === "string"
+        ? err.stdout.trimEnd()
+        : "";
+    const stderr =
+      typeof err === "object" && err !== null && "stderr" in err && typeof err.stderr === "string"
+        ? err.stderr.trimEnd()
+        : formatExecError(err);
+    const exitCode =
+      typeof err === "object" && err !== null && "code" in err && typeof err.code === "number"
+        ? err.code
+        : 1;
+    return { exitCode, stdout, stderr };
+  }
+}
+
+function parseClaudeStatus(stdout: string, stderr: string, exitCode: number): AccountAuthCheck {
+  const fallbackSummary = stdout || stderr || `claude auth status exited with code ${exitCode}`;
+  try {
+    const parsed = JSON.parse(stdout) as unknown;
+    if (typeof parsed !== "object" || parsed === null) {
+      return { ok: false, summary: fallbackSummary };
+    }
+
+    const record = parsed as Record<string, unknown>;
+
+    const loggedIn = record["loggedIn"] === true;
+    const authMethod =
+      typeof record["authMethod"] === "string" ? record["authMethod"] : null;
+    const apiKeySource =
+      typeof record["apiKeySource"] === "string"
+        ? record["apiKeySource"]
+        : null;
+
+    return {
+      ok: loggedIn,
+      summary: loggedIn
+        ? [authMethod, apiKeySource].filter(Boolean).join(" · ") || "authenticated"
+        : "not authenticated",
+      details: record,
+    };
+  } catch {
+    return { ok: false, summary: fallbackSummary };
+  }
+}
+
+function parseCodexStatus(stdout: string, stderr: string, exitCode: number): AccountAuthCheck {
+  const output = stdout || stderr;
+  if (/logged in/i.test(output) && !/not logged in/i.test(output)) {
+    return { ok: true, summary: output.split("\n")[0] ?? "authenticated" };
+  }
+  if (/not logged in/i.test(output)) {
+    return { ok: false, summary: "not authenticated" };
+  }
+  return {
+    ok: exitCode === 0,
+    summary: output.split("\n")[0] ?? `codex login status exited with code ${exitCode}`,
+  };
+}
+
+export async function testAccountAuth(
+  accountId: string,
+  account: AccountConfig,
+): Promise<AccountAuthCheck> {
+  const command = getAccountStatusCommand(account);
+  if (!command) {
+    return {
+      ok: false,
+      summary: `auth status is not supported for agent '${account.agent}'`,
+    };
+  }
+
+  const accountDir = getAccountDataDir(accountId);
+  if (!existsSync(accountDir)) {
+    return {
+      ok: false,
+      summary: "not authenticated",
+      details: { accountDir, initialized: false },
+    };
+  }
+
+  const env = getAccountEnvironment(accountId, account, { useApiKeyFallback: false });
+  const result = await runCommand(command.command, command.args, env);
+
+  switch (account.agent) {
+    case "claude-code":
+      return parseClaudeStatus(result.stdout, result.stderr, result.exitCode);
+    case "codex":
+      return parseCodexStatus(result.stdout, result.stderr, result.exitCode);
+    default:
+      return {
+        ok: result.exitCode === 0,
+        summary: result.stdout || result.stderr || `command exited with code ${result.exitCode}`,
+      };
+  }
+}
+
+export async function loginAccount(accountId: string, account: AccountConfig): Promise<number> {
+  const command = getAccountLoginCommand(account);
+  if (!command) {
+    throw new Error(`Interactive login is not supported for agent '${account.agent}'`);
+  }
+
+  await mkdir(getAccountDataDir(accountId), { recursive: true });
+
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    const child = spawn(command.command, command.args, {
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        ...getAccountEnvironment(accountId, account, { useApiKeyFallback: false }),
+      },
+    });
+
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (typeof code === "number") {
+        resolve(code);
+        return;
+      }
+      reject(new Error(`${command.command} exited due to signal ${signal ?? "unknown"}`));
+    });
+  });
+
+  return exitCode;
+}
+
+export function resolveSessionAccountId(config: OrchestratorConfig, session: Session): string {
+  const persistedAccountId = session.metadata["accountId"];
+  if (persistedAccountId) {
+    return persistedAccountId;
+  }
+
+  const persistedAgent = session.metadata["agent"];
+  return resolveAccountForProject(config, session.projectId, undefined, persistedAgent);
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -13,6 +13,7 @@ import { registerLifecycleWorker } from "./commands/lifecycle-worker.js";
 import { registerServices } from "./commands/services.js";
 import { registerVerify } from "./commands/verify.js";
 import { registerCapacity } from "./commands/capacity.js";
+import { registerAccounts } from "./commands/accounts.js";
 
 export function createProgram(): Command {
   const program = new Command();
@@ -38,6 +39,7 @@ export function createProgram(): Command {
   registerLifecycleWorker(program);
   registerVerify(program);
   registerCapacity(program);
+  registerAccounts(program);
 
   return program;
 }

--- a/packages/core/src/__tests__/accounts.test.ts
+++ b/packages/core/src/__tests__/accounts.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getAccountEnvironment,
+  parseQuotaWindowHours,
+  resolveAccount,
+  type OrchestratorConfig,
+} from "../index.js";
+
+function makeConfig(overrides: Partial<OrchestratorConfig> = {}): OrchestratorConfig {
+  return {
+    configPath: "/tmp/syntese.yaml",
+    port: 3000,
+    readyThresholdMs: 300_000,
+    defaults: {
+      runtime: "tmux",
+      agent: "claude-code",
+      workspace: "worktree",
+      notifiers: [],
+    },
+    projects: {
+      app: {
+        name: "App",
+        repo: "org/app",
+        path: "/tmp/app",
+        defaultBranch: "main",
+        sessionPrefix: "app",
+      },
+    },
+    notifiers: {},
+    notificationRouting: { urgent: [], action: [], warning: [], info: [] },
+    reactions: {},
+    progressChecks: {
+      enabled: false,
+      intervalMinutes: 10,
+      terminalLines: 50,
+      signals: { errorPatterns: [], testPatterns: [], livePatterns: [] },
+    },
+    ...overrides,
+  };
+}
+
+const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
+const originalAnthropicApiKey = process.env.ANTHROPIC_API_KEY;
+const originalClaudeApiKey = process.env.CLAUDE_API_KEY;
+
+afterEach(() => {
+  if (originalOpenAiApiKey === undefined) {
+    delete process.env.OPENAI_API_KEY;
+  } else {
+    process.env.OPENAI_API_KEY = originalOpenAiApiKey;
+  }
+
+  if (originalAnthropicApiKey === undefined) {
+    delete process.env.ANTHROPIC_API_KEY;
+  } else {
+    process.env.ANTHROPIC_API_KEY = originalAnthropicApiKey;
+  }
+
+  if (originalClaudeApiKey === undefined) {
+    delete process.env.CLAUDE_API_KEY;
+  } else {
+    process.env.CLAUDE_API_KEY = originalClaudeApiKey;
+  }
+});
+
+describe("parseQuotaWindowHours", () => {
+  it("parses hour, minute, and day windows", () => {
+    expect(parseQuotaWindowHours("5h")).toBe(5);
+    expect(parseQuotaWindowHours("90m")).toBe(1.5);
+    expect(parseQuotaWindowHours("2d")).toBe(48);
+  });
+
+  it("returns null for invalid input", () => {
+    expect(parseQuotaWindowHours(undefined)).toBeNull();
+    expect(parseQuotaWindowHours("soon")).toBeNull();
+  });
+});
+
+describe("resolveAccount", () => {
+  it("returns the selected explicit account", () => {
+    const config = makeConfig({
+      accounts: {
+        "codex-pro-1": { agent: "codex" },
+      },
+    });
+
+    const resolved = resolveAccount(config, {
+      projectId: "app",
+      accountId: "codex-pro-1",
+      agentName: "codex",
+    });
+
+    expect(resolved.accountId).toBe("codex-pro-1");
+    expect(resolved.account.agent).toBe("codex");
+  });
+
+  it("falls back to an implicit account when none are configured", () => {
+    const config = makeConfig();
+    const resolved = resolveAccount(config, { projectId: "app" });
+
+    expect(resolved.accountId).toBe("claude-code");
+    expect(resolved.account).toEqual({ agent: "claude-code" });
+  });
+
+  it("rejects an explicit account whose agent mismatches the session agent", () => {
+    const config = makeConfig({
+      accounts: {
+        "codex-pro-1": { agent: "codex" },
+      },
+    });
+
+    expect(() =>
+      resolveAccount(config, {
+        projectId: "app",
+        accountId: "codex-pro-1",
+        agentName: "claude-code",
+      }),
+    ).toThrow(/uses agent 'codex'/);
+  });
+});
+
+describe("getAccountEnvironment", () => {
+  it("uses CODEX_HOME and clears OPENAI_API_KEY by default", () => {
+    process.env.OPENAI_API_KEY = "test-openai-key";
+
+    const env = getAccountEnvironment("codex-pro-1", { agent: "codex" });
+
+    expect(env.CODEX_HOME).toContain("accounts/codex-pro-1");
+    expect(env.OPENAI_API_KEY).toBe("");
+  });
+
+  it("allows OPENAI_API_KEY fallback when enabled", () => {
+    process.env.OPENAI_API_KEY = "test-openai-key";
+
+    const env = getAccountEnvironment(
+      "codex-pro-1",
+      { agent: "codex", limits: { apiKeyFallback: true } },
+      { useApiKeyFallback: true },
+    );
+
+    expect(env.OPENAI_API_KEY).toBe("test-openai-key");
+  });
+
+  it("uses CLAUDE_CONFIG_DIR and clears Anthropic auth env vars", () => {
+    process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+    process.env.CLAUDE_API_KEY = "test-claude-key";
+
+    const env = getAccountEnvironment("claude-max-1", { agent: "claude-code" });
+
+    expect(env.CLAUDE_CONFIG_DIR).toContain("accounts/claude-max-1");
+    expect(env.ANTHROPIC_API_KEY).toBe("");
+    expect(env.CLAUDE_API_KEY).toBe("");
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("");
+  });
+
+  it("allows Claude API-key fallback when enabled", () => {
+    process.env.ANTHROPIC_API_KEY = "test-anthropic-key";
+    process.env.CLAUDE_API_KEY = "test-claude-key";
+
+    const env = getAccountEnvironment(
+      "claude-max-1",
+      { agent: "claude-code", limits: { apiKeyFallback: true } },
+      { useApiKeyFallback: true },
+    );
+
+    expect(env.ANTHROPIC_API_KEY).toBe("test-anthropic-key");
+    expect(env.CLAUDE_API_KEY).toBe("test-claude-key");
+  });
+});

--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -496,3 +496,126 @@ describe("Config Defaults", () => {
     expect(validated.projects.proj1.scm).toEqual({ plugin: "gitlab" });
   });
 });
+
+describe("Account Registry Config", () => {
+  it("accepts agentPool.accounts and normalizes them into config.accounts", () => {
+    const validated = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+        },
+      },
+      agentPool: {
+        accounts: [
+          {
+            id: "codex-pro-1",
+            agent: "codex",
+            model: "gpt-5.4-xhigh",
+            auth: { profile: "joakim-chatgpt" },
+            limits: {
+              quotaWindow: "5h",
+              overageType: "credits",
+              overageEnabled: true,
+              overageSpendCap: 50,
+              apiKeyFallback: true,
+            },
+          },
+        ],
+      },
+    });
+
+    expect(validated.accounts?.["codex-pro-1"]).toMatchObject({
+      agent: "codex",
+      model: "gpt-5.4-xhigh",
+      auth: { profile: "joakim-chatgpt" },
+      limits: {
+        quotaWindow: "5h",
+        overageType: "credits",
+        overageEnabled: true,
+        overageSpendCap: 50,
+        apiKeyFallback: true,
+      },
+      baseQuota: {
+        estimatedTotal: 0,
+        windowHours: 5,
+      },
+      overage: {
+        enabled: true,
+        type: "credits",
+        spendCap: 50,
+      },
+    });
+    expect(validated.agentPool?.accounts).toHaveLength(1);
+    const configuredAccounts = validated.agentPool?.accounts ?? [];
+    expect(configuredAccounts[0]?.id).toBe("codex-pro-1");
+  });
+
+  it("keeps legacy top-level accounts working", () => {
+    const validated = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+        },
+      },
+      accounts: {
+        "claude-max-1": {
+          agent: "claude-code",
+          auth: { profile: "company-claude" },
+        },
+      },
+    });
+
+    expect(validated.accounts?.["claude-max-1"]).toEqual({
+      agent: "claude-code",
+      auth: { profile: "company-claude" },
+    });
+    expect(validated.agentPool?.accounts).toEqual([
+      {
+        id: "claude-max-1",
+        agent: "claude-code",
+        auth: { profile: "company-claude" },
+      },
+    ]);
+  });
+
+  it("rejects duplicate account ids across legacy and agentPool config", () => {
+    expect(() =>
+      validateConfig({
+        projects: {
+          proj1: {
+            path: "/repos/test",
+            repo: "org/test",
+            defaultBranch: "main",
+          },
+        },
+        accounts: {
+          shared: { agent: "codex" },
+        },
+        agentPool: {
+          accounts: [{ id: "shared", agent: "codex" }],
+        },
+      }),
+    ).toThrow(/Duplicate account ID/);
+  });
+
+  it("rejects accounts with unknown agent plugins", () => {
+    expect(() =>
+      validateConfig({
+        projects: {
+          proj1: {
+            path: "/repos/test",
+            repo: "org/test",
+            defaultBranch: "main",
+          },
+        },
+        agentPool: {
+          accounts: [{ id: "mystery", agent: "unknown-agent" }],
+        },
+      }),
+    ).toThrow(/Unknown agent plugin/);
+  });
+});

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -13,7 +13,7 @@ import {
   reserveSessionId,
   updateMetadata,
 } from "../metadata.js";
-import { getSessionsDir, getProjectBaseDir, getWorktreesDir } from "../paths.js";
+import { getSessionsDir, getProjectBaseDir, getWorktreesDir, getAccountDataDir } from "../paths.js";
 import {
   SessionNotRestorableError,
   WorkspaceMissingError,
@@ -3168,6 +3168,83 @@ describe("spawnOrchestrator", () => {
     );
   });
 
+  it("injects the selected account environment and persists account metadata", async () => {
+    const codexAgent: Agent = {
+      ...mockAgent,
+      name: "codex",
+    };
+    const registryWithCodex: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return codexAgent;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+    const configWithAccounts: OrchestratorConfig = {
+      ...config,
+      accounts: {
+        "codex-pro-1": { agent: "codex" },
+      },
+    };
+
+    const sm = createSessionManager({ config: configWithAccounts, registry: registryWithCodex });
+    await sm.spawn({ projectId: "my-app", account: "codex-pro-1" });
+
+    const createCall = vi.mocked(mockRuntime.create).mock.calls[0]?.[0];
+    expect(createCall?.environment["CODEX_HOME"]).toBe(getAccountDataDir("codex-pro-1"));
+    expect(createCall?.environment["AO_ACCOUNT_ID"]).toBe("codex-pro-1");
+
+    const meta = readMetadataRaw(sessionsDir, "app-1");
+    expect(meta?.["accountId"]).toBe("codex-pro-1");
+  });
+
+  it("uses the same auth dir for shared accounts and different dirs for distinct accounts", async () => {
+    const codexAgent: Agent = {
+      ...mockAgent,
+      name: "codex",
+    };
+    const registryWithCodex: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return codexAgent;
+        if (slot === "workspace") return {
+          ...mockWorkspace,
+          create: vi.fn().mockImplementation(async ({ sessionId, branch, projectId }) => ({
+            path: `/tmp/mock-ws/${sessionId}`,
+            branch,
+            sessionId,
+            projectId,
+          })),
+        };
+        return null;
+      }),
+    };
+    const configWithAccounts: OrchestratorConfig = {
+      ...config,
+      accounts: {
+        "codex-pro-1": { agent: "codex" },
+        "codex-pro-2": { agent: "codex" },
+      },
+    };
+
+    const sm = createSessionManager({ config: configWithAccounts, registry: registryWithCodex });
+    await sm.spawn({ projectId: "my-app", account: "codex-pro-1" });
+    await sm.spawn({ projectId: "my-app", account: "codex-pro-1" });
+    await sm.spawn({ projectId: "my-app", account: "codex-pro-2" });
+
+    const firstEnv = vi.mocked(mockRuntime.create).mock.calls[0]?.[0].environment;
+    const secondEnv = vi.mocked(mockRuntime.create).mock.calls[1]?.[0].environment;
+    const thirdEnv = vi.mocked(mockRuntime.create).mock.calls[2]?.[0].environment;
+
+    expect(firstEnv["CODEX_HOME"]).toBe(getAccountDataDir("codex-pro-1"));
+    expect(secondEnv["CODEX_HOME"]).toBe(getAccountDataDir("codex-pro-1"));
+    expect(thirdEnv["CODEX_HOME"]).toBe(getAccountDataDir("codex-pro-2"));
+    expect(firstEnv["CODEX_HOME"]).not.toBe(thirdEnv["CODEX_HOME"]);
+  });
+
   it("does not persist orchestratorSessionReused metadata on newly created sessions", async () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
 
@@ -3437,6 +3514,50 @@ describe("restore", () => {
     expect(meta!["issue"]).toBe("TEST-1");
     expect(meta!["pr"]).toBe("https://github.com/org/my-app/pull/10");
     expect(meta!["createdAt"]).toBe("2025-01-01T00:00:00.000Z");
+  });
+
+  it("restores using the persisted account environment", async () => {
+    const claudeAgent: Agent = {
+      ...mockAgent,
+      name: "claude-code",
+    };
+    const registryWithClaude: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return claudeAgent;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+    const configWithAccounts: OrchestratorConfig = {
+      ...config,
+      accounts: {
+        "claude-max-1": { agent: "claude-code" },
+      },
+    };
+    const wsPath = join(tmpDir, "ws-app-restore-account");
+    mkdirSync(wsPath, { recursive: true });
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: wsPath,
+      branch: "feat/TEST-1",
+      status: "killed",
+      project: "my-app",
+      agent: "claude-code",
+      accountId: "claude-max-1",
+      runtimeHandle: JSON.stringify(makeHandle("rt-old")),
+    });
+
+    const sm = createSessionManager({ config: configWithAccounts, registry: registryWithClaude });
+    await sm.restore("app-1");
+
+    const createCall = vi.mocked(mockRuntime.create).mock.calls[0]?.[0];
+    expect(createCall?.environment["CLAUDE_CONFIG_DIR"]).toBe(getAccountDataDir("claude-max-1"));
+    expect(createCall?.environment["AO_ACCOUNT_ID"]).toBe("claude-max-1");
+
+    const meta = readMetadataRaw(sessionsDir, "app-1");
+    expect(meta?.["accountId"]).toBe("claude-max-1");
   });
 
   it("continues restore even if old runtime destroy fails", async () => {

--- a/packages/core/src/accounts.ts
+++ b/packages/core/src/accounts.ts
@@ -1,0 +1,243 @@
+import { getAccountDataDir } from "./paths.js";
+import type { AccountConfig, OrchestratorConfig } from "./types.js";
+
+export interface ResolvedAccount {
+  accountId: string;
+  account: AccountConfig;
+}
+
+export interface AccountCommand {
+  command: string;
+  args: string[];
+}
+
+export interface AccountEnvironmentOptions {
+  useApiKeyFallback?: boolean;
+}
+
+const DEFAULT_QUOTA_WINDOW_HOURS = 5;
+
+const CODEX_AUTH_ENV_KEYS = ["OPENAI_API_KEY"] as const;
+
+const CLAUDE_AUTH_ENV_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "CLAUDE_API_KEY",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "CLAUDE_CODE_OAUTH_REFRESH_TOKEN",
+  "CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR",
+  "CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR",
+] as const;
+
+function clearEnvironment(keys: readonly string[]): Record<string, string> {
+  return Object.fromEntries(keys.map((key) => [key, ""]));
+}
+
+function maybeSetFallbackEnv(
+  env: Record<string, string>,
+  keys: readonly string[],
+  enabled: boolean,
+): void {
+  if (!enabled) {
+    return;
+  }
+
+  for (const key of keys) {
+    const value = process.env[key];
+    if (typeof value === "string" && value.length > 0) {
+      env[key] = value;
+    }
+  }
+}
+
+export function getConfiguredAccounts(config: OrchestratorConfig): Record<string, AccountConfig> {
+  return config.accounts ?? {};
+}
+
+/**
+ * Get all account configs: explicit ones from config.accounts plus implicit
+ * defaults derived from agent types used across projects.
+ */
+export function getEffectiveAccounts(config: OrchestratorConfig): Record<string, AccountConfig> {
+  const explicit = getConfiguredAccounts(config);
+  const agentsCovered = new Set(Object.values(explicit).map((account) => account.agent));
+
+  const implicit: Record<string, AccountConfig> = {};
+  for (const project of Object.values(config.projects)) {
+    const agentName = project.agent ?? config.defaults.agent;
+    if (agentsCovered.has(agentName)) {
+      continue;
+    }
+
+    implicit[agentName] = { agent: agentName };
+    agentsCovered.add(agentName);
+  }
+
+  return { ...implicit, ...explicit };
+}
+
+export function resolveAccount(
+  config: OrchestratorConfig,
+  options: { projectId: string; accountId?: string; agentName?: string },
+): ResolvedAccount {
+  const project = config.projects[options.projectId];
+  if (!project) {
+    throw new Error(`Unknown project: ${options.projectId}`);
+  }
+
+  const effectiveAgent = options.agentName ?? project.agent ?? config.defaults.agent;
+  const explicitAccounts = getConfiguredAccounts(config);
+
+  if (options.accountId) {
+    const explicit = explicitAccounts[options.accountId];
+    if (explicit) {
+      if (explicit.agent !== effectiveAgent) {
+        throw new Error(
+          `Account '${options.accountId}' uses agent '${explicit.agent}', but this session uses '${effectiveAgent}'`,
+        );
+      }
+      return { accountId: options.accountId, account: explicit };
+    }
+
+    if (options.accountId === effectiveAgent) {
+      return {
+        accountId: options.accountId,
+        account: { agent: effectiveAgent },
+      };
+    }
+
+    throw new Error(`Unknown account: ${options.accountId}`);
+  }
+
+  for (const [accountId, account] of Object.entries(explicitAccounts)) {
+    if (account.agent === effectiveAgent) {
+      return { accountId, account };
+    }
+  }
+
+  return {
+    accountId: effectiveAgent,
+    account: { agent: effectiveAgent },
+  };
+}
+
+export function resolveAccountForProject(
+  config: OrchestratorConfig,
+  projectId: string,
+  accountId?: string,
+  agentName?: string,
+): string {
+  return resolveAccount(config, { projectId, accountId, agentName }).accountId;
+}
+
+export function parseQuotaWindowHours(quotaWindow: string | undefined): number | null {
+  if (!quotaWindow) {
+    return null;
+  }
+
+  const match = /^\s*(\d+(?:\.\d+)?)\s*([mhd])\s*$/i.exec(quotaWindow);
+  if (!match) {
+    return null;
+  }
+
+  const value = Number.parseFloat(match[1]);
+  const unit = match[2]?.toLowerCase();
+  if (!Number.isFinite(value) || value <= 0 || !unit) {
+    return null;
+  }
+
+  switch (unit) {
+    case "m":
+      return value / 60;
+    case "h":
+      return value;
+    case "d":
+      return value * 24;
+    default:
+      return null;
+  }
+}
+
+export function getAccountWindowHours(account: AccountConfig): number {
+  return (
+    account.baseQuota?.windowHours ??
+    parseQuotaWindowHours(account.limits?.quotaWindow) ??
+    DEFAULT_QUOTA_WINDOW_HOURS
+  );
+}
+
+export function getAccountOverageConfig(account: AccountConfig): {
+  enabled: boolean;
+  type: "credits" | "api-rates";
+  spendCap: number;
+} | null {
+  if (account.overage) {
+    return {
+      enabled: account.overage.enabled,
+      type: account.overage.type ?? "credits",
+      spendCap: account.overage.spendCap ?? 0,
+    };
+  }
+
+  if (account.limits?.overageEnabled) {
+    return {
+      enabled: true,
+      type: account.limits.overageType ?? "credits",
+      spendCap: account.limits.overageSpendCap ?? 0,
+    };
+  }
+
+  return null;
+}
+
+export function getAccountEnvironment(
+  accountId: string,
+  account: AccountConfig,
+  options: AccountEnvironmentOptions = {},
+): Record<string, string> {
+  const allowApiKeyFallback = options.useApiKeyFallback === true && account.limits?.apiKeyFallback === true;
+  const accountDir = getAccountDataDir(accountId);
+
+  switch (account.agent) {
+    case "codex": {
+      const env = {
+        CODEX_HOME: accountDir,
+        ...clearEnvironment(CODEX_AUTH_ENV_KEYS),
+      };
+      maybeSetFallbackEnv(env, CODEX_AUTH_ENV_KEYS, allowApiKeyFallback);
+      return env;
+    }
+    case "claude-code": {
+      const env = {
+        CLAUDE_CONFIG_DIR: accountDir,
+        ...clearEnvironment(CLAUDE_AUTH_ENV_KEYS),
+      };
+      maybeSetFallbackEnv(env, ["ANTHROPIC_API_KEY", "CLAUDE_API_KEY"], allowApiKeyFallback);
+      return env;
+    }
+    default:
+      return {};
+  }
+}
+
+export function getAccountLoginCommand(account: AccountConfig): AccountCommand | null {
+  switch (account.agent) {
+    case "codex":
+      return { command: "codex", args: ["login"] };
+    case "claude-code":
+      return { command: "claude", args: ["auth", "login"] };
+    default:
+      return null;
+  }
+}
+
+export function getAccountStatusCommand(account: AccountConfig): AccountCommand | null {
+  switch (account.agent) {
+    case "codex":
+      return { command: "codex", args: ["login", "status"] };
+    case "claude-code":
+      return { command: "claude", args: ["auth", "status", "--json"] };
+    default:
+      return null;
+  }
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -18,7 +18,9 @@ import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import { PRIMARY_CLI_COMMAND } from "./cli-command.js";
 import type { OrchestratorConfig } from "./types.js";
+import { parseQuotaWindowHours } from "./accounts.js";
 import { generateSessionPrefix } from "./paths.js";
+import { listBuiltinPluginNames } from "./plugin-registry.js";
 
 const CONFIG_FILENAMES = [
   "syntese.yaml",
@@ -38,6 +40,9 @@ const HOME_CONFIG_PATHS = [
 
 const MISSING_CONFIG_ERROR =
   `No syntese.yaml found (legacy agent-orchestrator.yaml is also supported). Run \`${PRIMARY_CLI_COMMAND} init\` to create one.`;
+
+const ACCOUNT_ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/;
+const KNOWN_ACCOUNT_AGENTS = new Set(listBuiltinPluginNames("agent"));
 
 function inferScmPlugin(project: {
   repo: string;
@@ -227,11 +232,35 @@ const AccountOverageSchema = z.object({
   spendCap: z.number().nonnegative().optional(),
 });
 
+const AccountAuthSchema = z.object({
+  profile: z.string().min(1).optional(),
+});
+
+const AccountLimitsSchema = z.object({
+  quotaWindow: z.string().min(1).optional(),
+  overageType: z.enum(["credits", "api-rates"]).optional(),
+  overageEnabled: z.boolean().optional(),
+  overageSpendCap: z.number().nonnegative().optional(),
+  apiKeyFallback: z.boolean().optional(),
+});
+
 const AccountConfigSchema = z.object({
   agent: z.string(),
   model: z.string().optional(),
+  auth: AccountAuthSchema.optional(),
+  limits: AccountLimitsSchema.optional(),
   baseQuota: AccountBaseQuotaSchema.optional(),
   overage: AccountOverageSchema.optional(),
+});
+
+const ConfiguredAccountSchema = AccountConfigSchema.extend({
+  id: z
+    .string()
+    .regex(ACCOUNT_ID_PATTERN, "account id must match [a-zA-Z0-9][a-zA-Z0-9_-]*"),
+});
+
+const AgentPoolConfigSchema = z.object({
+  accounts: z.array(ConfiguredAccountSchema).default([]),
 });
 
 const OrchestratorConfigSchema = z.object({
@@ -250,8 +279,81 @@ const OrchestratorConfigSchema = z.object({
   }),
   reactions: z.record(ReactionConfigSchema).default({}),
   progressChecks: ProgressChecksSchema.default({}),
+  agentPool: AgentPoolConfigSchema.optional(),
   accounts: z.record(AccountConfigSchema).optional(),
 });
+
+function normalizeAccounts(config: OrchestratorConfig): OrchestratorConfig {
+  const normalized: Record<string, NonNullable<OrchestratorConfig["accounts"]>[string]> = {};
+  const configuredAccounts = config.agentPool?.accounts ?? [];
+
+  const register = (accountId: string, account: NonNullable<OrchestratorConfig["accounts"]>[string]): void => {
+    if (!ACCOUNT_ID_PATTERN.test(accountId)) {
+      throw new Error(
+        `Invalid account ID '${accountId}': must match [a-zA-Z0-9][a-zA-Z0-9_-]*`,
+      );
+    }
+
+    if (normalized[accountId]) {
+      throw new Error(`Duplicate account ID detected: '${accountId}'`);
+    }
+
+    if (!KNOWN_ACCOUNT_AGENTS.has(account.agent)) {
+      throw new Error(
+        `Unknown agent plugin for account '${accountId}': '${account.agent}'. Known agents: ${[...KNOWN_ACCOUNT_AGENTS].join(", ")}`,
+      );
+    }
+
+    const windowHours =
+      account.baseQuota?.windowHours ?? parseQuotaWindowHours(account.limits?.quotaWindow) ?? undefined;
+    const baseQuota = account.baseQuota
+      ? {
+          ...account.baseQuota,
+          ...(windowHours !== undefined ? { windowHours } : {}),
+        }
+      : account.limits?.quotaWindow && windowHours !== undefined
+        ? {
+            estimatedTotal: 0,
+            windowHours,
+          }
+        : undefined;
+
+    normalized[accountId] = {
+      ...account,
+      ...(baseQuota ? { baseQuota } : {}),
+      ...(account.overage
+        ? {}
+        : account.limits?.overageEnabled
+          ? {
+              overage: {
+                enabled: true,
+                type: account.limits.overageType,
+                spendCap: account.limits.overageSpendCap,
+              },
+            }
+          : {}),
+    };
+  };
+
+  for (const [accountId, account] of Object.entries(config.accounts ?? {})) {
+    register(accountId, account);
+  }
+
+  for (const configuredAccount of configuredAccounts) {
+    const { id, ...account } = configuredAccount;
+    register(id, account);
+  }
+
+  config.accounts = Object.keys(normalized).length > 0 ? normalized : undefined;
+  config.agentPool =
+    Object.keys(normalized).length > 0
+      ? {
+          accounts: Object.entries(normalized).map(([id, account]) => ({ id, ...account })),
+        }
+      : undefined;
+
+  return config;
+}
 
 // =============================================================================
 // CONFIG LOADING
@@ -569,6 +671,7 @@ export function validateConfig(raw: unknown): OrchestratorConfig {
   const validated = OrchestratorConfigSchema.parse(raw);
 
   let config = validated as OrchestratorConfig;
+  config = normalizeAccounts(config);
   config = expandPaths(config);
   config = applyProjectDefaults(config);
   config = applyDefaultReactions(config);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -123,8 +123,6 @@ export {
   incrementAccountConsumed,
   calibrateAccountConsumed,
   computeAccountCapacity,
-  getEffectiveAccounts,
-  resolveAccountForProject,
   getActiveSessionsByAccount,
   persistAccountUsageSnapshot,
   refreshAccountUsageSnapshots,
@@ -173,6 +171,21 @@ export {
   getAccountDataDir,
   getAccountCapacityFile,
 } from "./paths.js";
+
+// Account registry + auth helpers
+export {
+  getConfiguredAccounts,
+  getEffectiveAccounts,
+  resolveAccount,
+  resolveAccountForProject,
+  parseQuotaWindowHours,
+  getAccountWindowHours,
+  getAccountOverageConfig,
+  getAccountEnvironment,
+  getAccountLoginCommand,
+  getAccountStatusCommand,
+} from "./accounts.js";
+export type { ResolvedAccount, AccountCommand, AccountEnvironmentOptions } from "./accounts.js";
 
 // Config generator — auto-generate config from repo URL
 export {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -76,6 +76,7 @@ export function readMetadata(dataDir: string, sessionId: SessionId): SessionMeta
     branch: raw["branch"] ?? "",
     status: raw["status"] ?? "unknown",
     tmuxName: raw["tmuxName"],
+    accountId: raw["accountId"],
     issue: raw["issue"],
     pr: raw["pr"],
     prAutoDetect:
@@ -145,6 +146,7 @@ export function writeMetadata(
   };
 
   if (metadata.tmuxName) data["tmuxName"] = metadata.tmuxName;
+  if (metadata.accountId) data["accountId"] = metadata.accountId;
   if (metadata.issue) data["issue"] = metadata.issue;
   if (metadata.pr) data["pr"] = metadata.pr;
   if (metadata.prAutoDetect) data["prAutoDetect"] = metadata.prAutoDetect;

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -53,6 +53,10 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "terminal", name: "web", pkg: "@syntese/plugin-terminal-web" },
 ];
 
+export function listBuiltinPluginNames(slot: PluginSlot): string[] {
+  return BUILTIN_PLUGINS.filter((plugin) => plugin.slot === slot).map((plugin) => plugin.name);
+}
+
 /** Extract plugin-specific config from orchestrator config */
 function extractPluginConfig(
   slot: PluginSlot,

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -66,6 +66,7 @@ import {
 } from "./paths.js";
 import { asValidOpenCodeSessionId } from "./opencode-session-id.js";
 import { normalizeOrchestratorSessionStrategy } from "./orchestrator-session-strategy.js";
+import { getAccountEnvironment, resolveAccount } from "./accounts.js";
 import {
   GLOBAL_PAUSE_REASON_KEY,
   GLOBAL_PAUSE_SOURCE_KEY,
@@ -1112,6 +1113,40 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       subagent: spawnConfig.subagent ?? configuredSubagent,
     };
 
+    const selectedAgentName = plugins.agent.name;
+    const routingSessions = listAllSessions().flatMap(({ sessionName, projectId: sessionProjectId }) => {
+      const sessionProject = config.projects[sessionProjectId];
+      if (!sessionProject) {
+        return [] as Session[];
+      }
+
+      const raw = readMetadataRaw(getProjectSessionsDir(sessionProject), sessionName);
+      if (!raw) {
+        return [] as Session[];
+      }
+
+      return [metadataToSession(sessionName, raw)];
+    });
+
+    const accountId =
+      spawnConfig.account ??
+      (await selectAccountForProject(
+        config,
+        spawnConfig.projectId,
+        registry,
+        routingSessions,
+        {
+          agent: selectedAgentName,
+          model: project.agentConfig?.model,
+        },
+      ).catch(() => resolveAccountForProject(config, spawnConfig.projectId, { agent: selectedAgentName })));
+
+    const resolvedAccount = resolveAccount(config, {
+      projectId: spawnConfig.projectId,
+      accountId,
+      agentName: selectedAgentName,
+    });
+
     let handle: RuntimeHandle;
     try {
       const launchCommand = plugins.agent.getLaunchCommand(agentLaunchConfig);
@@ -1123,9 +1158,16 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         launchCommand,
         environment: {
           ...environment,
+          ...getAccountEnvironment(resolvedAccount.accountId, resolvedAccount.account, {
+            useApiKeyFallback: true,
+          }),
           AO_SESSION: sessionId,
           AO_DATA_DIR: sessionsDir, // Pass sessions directory (not root dataDir)
           AO_SESSION_NAME: sessionId, // User-facing session name
+          AO_ACCOUNT_ID: resolvedAccount.accountId,
+          ...(resolvedAccount.account.auth?.profile
+            ? { AO_AUTH_PROFILE: resolvedAccount.account.auth.profile }
+            : {}),
           ...(tmuxName && { AO_TMUX_NAME: tmuxName }), // Tmux session name if using new arch
         },
       });
@@ -1164,39 +1206,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       createdAt: new Date(),
       lastActivityAt: new Date(),
       metadata: {
+        accountId: resolvedAccount.accountId,
         ...(reusedOpenCodeSessionId ? { opencodeSessionId: reusedOpenCodeSessionId } : {}),
       },
     };
-    const selectedAgentName = plugins.agent.name;
-
-    const routingSessions = listAllSessions().flatMap(({ sessionName, projectId: sessionProjectId }) => {
-      const sessionProject = config.projects[sessionProjectId];
-      if (!sessionProject) {
-        return [] as Session[];
-      }
-
-      const raw = readMetadataRaw(getProjectSessionsDir(sessionProject), sessionName);
-      if (!raw) {
-        return [] as Session[];
-      }
-
-      return [metadataToSession(sessionName, raw)];
-    });
-
-    const accountId = await selectAccountForProject(
-      config,
-      spawnConfig.projectId,
-      registry,
-      routingSessions,
-      {
-        agent: selectedAgentName,
-        model: project.agentConfig?.model,
-      },
-    ).catch(() =>
-      resolveAccountForProject(config, spawnConfig.projectId, { agent: selectedAgentName }),
-    );
-
-    session.metadata["accountId"] = accountId;
+    session.metadata["accountId"] = resolvedAccount.accountId;
 
     try {
       writeMetadata(sessionsDir, sessionId, {
@@ -1204,10 +1218,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         branch,
         status: "spawning",
         tmuxName, // Store tmux name for mapping
+        accountId: resolvedAccount.accountId,
         issue: spawnConfig.issueId,
         project: spawnConfig.projectId,
         agent: selectedAgentName, // Persist agent name for lifecycle manager
-        accountId,
         createdAt: new Date().toISOString(),
         runtimeHandle: JSON.stringify(handle),
         opencodeSessionId: reusedOpenCodeSessionId,
@@ -1439,6 +1453,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     const launchCommand = plugins.agent.getLaunchCommand(agentLaunchConfig);
     const environment = plugins.agent.getEnvironment(agentLaunchConfig);
+    const resolvedAccount = resolveAccount(config, {
+      projectId: orchestratorConfig.projectId,
+      agentName: plugins.agent.name,
+    });
 
     const handle = await plugins.runtime.create({
       sessionId: tmuxName ?? sessionId,
@@ -1446,9 +1464,16 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       launchCommand,
       environment: {
         ...environment,
+        ...getAccountEnvironment(resolvedAccount.accountId, resolvedAccount.account, {
+          useApiKeyFallback: true,
+        }),
         AO_SESSION: sessionId,
         AO_DATA_DIR: sessionsDir,
         AO_SESSION_NAME: sessionId,
+        AO_ACCOUNT_ID: resolvedAccount.accountId,
+        ...(resolvedAccount.account.auth?.profile
+          ? { AO_AUTH_PROFILE: resolvedAccount.account.auth.profile }
+          : {}),
         ...(tmuxName && { AO_TMUX_NAME: tmuxName }),
       },
     });
@@ -1468,6 +1493,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       createdAt: new Date(),
       lastActivityAt: new Date(),
       metadata: {
+        accountId: resolvedAccount.accountId,
         ...(reusableOpenCodeSessionId ? { opencodeSessionId: reusableOpenCodeSessionId } : {}),
       },
     };
@@ -1479,6 +1505,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         status: "working",
         role: "orchestrator",
         tmuxName,
+        accountId: resolvedAccount.accountId,
         project: orchestratorConfig.projectId,
         agent: plugins.agent.name,
         createdAt: new Date().toISOString(),
@@ -2538,6 +2565,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         tmuxName: raw["tmuxName"],
         issue: raw["issue"],
         pr: raw["pr"],
+        accountId: raw["accountId"],
         prAutoDetect:
           raw["prAutoDetect"] === "off" ? "off" : raw["prAutoDetect"] === "on" ? "on" : undefined,
         summary: raw["summary"],
@@ -2629,6 +2657,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       subagent: configuredSubagent,
     };
 
+    const resolvedAccount = resolveAccount(config, {
+      projectId: session.projectId,
+      accountId: raw["accountId"],
+      agentName: raw["agent"] ?? project.agent ?? config.defaults.agent,
+    });
+
     if (plugins.agent.getRestoreCommand) {
       const restoreCmd = await plugins.agent.getRestoreCommand(session, project);
       launchCommand = restoreCmd ?? plugins.agent.getLaunchCommand(agentLaunchConfig);
@@ -2646,9 +2680,16 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       launchCommand,
       environment: {
         ...environment,
+        ...getAccountEnvironment(resolvedAccount.accountId, resolvedAccount.account, {
+          useApiKeyFallback: true,
+        }),
         AO_SESSION: sessionId,
         AO_DATA_DIR: sessionsDir,
         AO_SESSION_NAME: sessionId,
+        AO_ACCOUNT_ID: resolvedAccount.accountId,
+        ...(resolvedAccount.account.auth?.profile
+          ? { AO_AUTH_PROFILE: resolvedAccount.account.auth.profile }
+          : {}),
         ...(tmuxName && { AO_TMUX_NAME: tmuxName }),
       },
     });
@@ -2657,6 +2698,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const now = new Date().toISOString();
     updateMetadata(sessionsDir, sessionId, {
       status: "spawning",
+      accountId: resolvedAccount.accountId,
       runtimeHandle: JSON.stringify(handle),
       restoredAt: now,
     });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -184,6 +184,8 @@ export interface SessionSpawnConfig {
   prompt?: string;
   /** Override the agent plugin for this session (e.g. "codex", "claude-code") */
   agent?: string;
+  /** Select a specific configured account for this session. */
+  account?: string;
   /** Override the OpenCode subagent for this session (e.g. "sisyphus", "oracle") */
   subagent?: string;
   /** Decomposition context — ancestor task chain (passed to prompt builder) */
@@ -1042,7 +1044,10 @@ export interface OrchestratorConfig {
   /** Periodic per-session progress snapshots */
   progressChecks: ProgressChecksConfig;
 
-  /** Per-account capacity configuration (optional; backward compatible) */
+  /** Account registry (new schema). */
+  agentPool?: AgentPoolConfig;
+
+  /** Per-account capacity/auth configuration (legacy normalized shape; backward compatible) */
   accounts?: Record<string, AccountConfig>;
 }
 
@@ -1050,12 +1055,34 @@ export interface OrchestratorConfig {
 // ACCOUNT CAPACITY
 // =============================================================================
 
+export interface AccountAuthConfig {
+  /** Human-readable auth profile or context label. */
+  profile?: string;
+}
+
+export interface AccountLimitsConfig {
+  /** Rolling quota window (e.g. "5h"). */
+  quotaWindow?: string;
+  /** Overage mode once the base quota is depleted. */
+  overageType?: "credits" | "api-rates";
+  /** Whether overage is allowed for this account. */
+  overageEnabled?: boolean;
+  /** Maximum spend cap for the overage period. */
+  overageSpendCap?: number;
+  /** Allow inheriting the process API key as a fallback for this account. */
+  apiKeyFallback?: boolean;
+}
+
 /** Account subscription/auth configuration */
 export interface AccountConfig {
   /** Agent type this account belongs to */
   agent: string;
   /** Model identifier, e.g. "claude-opus-4" */
   model?: string;
+  /** Auth context for this account. */
+  auth?: AccountAuthConfig;
+  /** Modern limits schema. */
+  limits?: AccountLimitsConfig;
   /** Base quota limits for the rolling window */
   baseQuota?: {
     /** Estimated total messages per window (e.g. 223 for Codex Pro) */
@@ -1070,6 +1097,15 @@ export interface AccountConfig {
     /** Maximum spend cap in dollars or credits */
     spendCap?: number;
   };
+}
+
+/** Account entry in `agentPool.accounts`. */
+export interface ConfiguredAccount extends AccountConfig {
+  id: string;
+}
+
+export interface AgentPoolConfig {
+  accounts?: ConfiguredAccount[];
 }
 
 /** Real-time headroom status for a single account */
@@ -1344,13 +1380,13 @@ export interface SessionMetadata {
   branch: string;
   status: string;
   tmuxName?: string; // Globally unique tmux session name (includes hash)
+  accountId?: string;
   issue?: string;
   pr?: string;
   prAutoDetect?: "on" | "off";
   summary?: string;
   project?: string;
   agent?: string; // Agent plugin name (e.g. "codex", "claude-code") — persisted for lifecycle
-  accountId?: string;
   createdAt?: string;
   runtimeHandle?: string;
   restoredAt?: string;

--- a/syntese.yaml.example
+++ b/syntese.yaml.example
@@ -22,6 +22,36 @@ defaults:
   workspace: worktree # worktree | clone | copy
   notifiers: [desktop] # desktop | slack | discord | webhook | email
 
+# Account registry for auth isolation across concurrent tmux sessions
+# Auth state is stored under ~/.syntese/accounts/<id>/
+# agentPool:
+#   accounts:
+#     - id: codex-pro-1
+#       agent: codex
+#       model: gpt-5.4-xhigh
+#       auth:
+#         profile: personal-codex
+#       limits:
+#         quotaWindow: 5h
+#         overageType: credits
+#         overageEnabled: true
+#         overageSpendCap: 50
+#         apiKeyFallback: true
+#     - id: claude-max-1
+#       agent: claude-code
+#       model: claude-opus-4
+#       auth:
+#         profile: company-claude
+#       limits:
+#         quotaWindow: 5h
+#         overageType: api-rates
+#         overageEnabled: true
+#         overageSpendCap: 100
+#
+# Login once per account: syn accounts login codex-pro-1
+# Test auth: syn accounts test codex-pro-1
+# Spawn with isolation: syn spawn my-app 123 --account codex-pro-1
+
 # Periodic progress snapshots for active sessions
 # progressChecks:
 #   enabled: true


### PR DESCRIPTION
## Summary
- add `agentPool.accounts` config support with normalized account registry helpers in core
- isolate Codex and Claude auth per account directory and inject account-specific env into spawned/restored sessions
- add `accounts` CLI commands, `spawn --account`, capacity/session accounting updates, docs, and regression coverage

## Validation
- `pnpm run typecheck`
- `pnpm test`
- `pnpm run lint`

Closes #64
