### PR TITLE
feat: add no-commit stuck timeout

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -269,6 +269,7 @@ reactions:
 reactions:
   agent-stuck:
     threshold: 10m # Consider stuck after 10 minutes of inactivity
+    noCommitTimeout: 20m # Warn if nothing has been pushed after 20 minutes
     action: notify
     priority: urgent
 ```

--- a/packages/cli/__tests__/commands/review-check.test.ts
+++ b/packages/cli/__tests__/commands/review-check.test.ts
@@ -272,6 +272,7 @@ describe("review-check command", () => {
     expect(mockSessionManager.send).toHaveBeenCalledWith(
       "app-1",
       expect.stringContaining("review comments"),
+      { resetNoCommitTimeout: true },
     );
     expect(mockExec).not.toHaveBeenCalled();
   });

--- a/packages/cli/__tests__/commands/send.test.ts
+++ b/packages/cli/__tests__/commands/send.test.ts
@@ -329,7 +329,9 @@ describe("send command", () => {
 
       await program.parseAsync(["node", "test", "send", "app-1", "hello", "opencode"]);
 
-      expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "hello opencode");
+      expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "hello opencode", {
+        resetNoCommitTimeout: true,
+      });
       expect(mockGetSessionsDir).toHaveBeenCalledWith("/tmp/syntese.yaml", "/tmp/my-app");
       expect(mockUpdateMetadata).toHaveBeenCalledWith(
         "/tmp/sessions",
@@ -373,7 +375,9 @@ describe("send command", () => {
 
       await program.parseAsync(["node", "test", "send", "app-1", "fix", "mapping"]);
 
-      expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "fix mapping");
+      expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "fix mapping", {
+        resetNoCommitTimeout: true,
+      });
       expect(consoleSpy).not.toHaveBeenCalledWith(
         expect.stringContaining("Waiting for app-1 to become idle"),
       );
@@ -408,7 +412,9 @@ describe("send command", () => {
 
       await program.parseAsync(["node", "test", "send", "app-1", "hello"]);
 
-      expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "hello");
+      expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "hello", {
+        resetNoCommitTimeout: true,
+      });
       expect(mockTmux).not.toHaveBeenCalledWith("has-session", "-t", expect.any(String));
     });
 
@@ -445,7 +451,9 @@ describe("send command", () => {
         rmSync(filePath, { force: true });
       }
 
-      expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "from file");
+      expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "from file", {
+        resetNoCommitTimeout: true,
+      });
     });
   });
 });

--- a/packages/cli/src/commands/review-check.ts
+++ b/packages/cli/src/commands/review-check.ts
@@ -138,7 +138,9 @@ export function registerReviewCheck(program: Command): void {
             const globalReaction = config.reactions["changes-requested"];
             const reviewFixPrompt =
               projectReaction?.message ?? globalReaction?.message ?? DEFAULT_REVIEW_FIX_PROMPT;
-            await sm.send(result.sessionId, reviewFixPrompt);
+            await sm.send(result.sessionId, reviewFixPrompt, {
+              resetNoCommitTimeout: true,
+            });
             console.log(chalk.green(`    -> Fix prompt sent`));
           } catch (err) {
             console.error(chalk.red(`    -> Failed to send: ${err}`));

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -209,7 +209,7 @@ export function registerSend(program: Command): void {
         }
 
         if (existingSession && sessionManager) {
-          await sessionManager.send(session, message);
+          await sessionManager.send(session, message, { resetNoCommitTimeout: true });
           markProgressCheckpointReset(config, existingSession);
           console.log(chalk.green("Message sent and processing"));
           return;

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -72,7 +72,7 @@ spawning → working → completed
 - `changes-requested` → send review comments to agent
 - `progress-checkpoints` → nudge sessions that miss early commit/PR milestones
 - `approved-and-green` → notify human (or auto-merge)
-- `agent-stuck` → notify human (`threshold` for idle sessions, optional `maxRuntime` for no-PR timeouts)
+- `agent-stuck` → notify human (`threshold` for idle sessions, optional `noCommitTimeout` for no-push sessions, optional `maxRuntime` for no-PR timeouts)
 
 **Polling loop:**
 

--- a/packages/core/__tests__/config.test.ts
+++ b/packages/core/__tests__/config.test.ts
@@ -158,7 +158,7 @@ reactions:
       );
     });
 
-    it("loads agent-stuck maxRuntime alongside the default stuck settings", () => {
+    it("loads agent-stuck maxRuntime and noCommitTimeout alongside the default stuck settings", () => {
       const configPath = join(testDir, "agent-stuck-config.yaml");
       writeFileSync(
         configPath,
@@ -172,6 +172,7 @@ reactions:
   agent-stuck:
     auto: true
     action: notify
+    noCommitTimeout: 20m
     maxRuntime: 30m
 `,
       );
@@ -185,6 +186,7 @@ reactions:
           priority: "urgent",
           refireIntervalMs: 300_000,
           threshold: "10m",
+          noCommitTimeout: "20m",
           maxRuntime: "30m",
         }),
       );

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { createHash, randomUUID } from "node:crypto";
 import { createLifecycleManager } from "../lifecycle-manager.js";
@@ -83,6 +83,14 @@ function runGit(cwd: string, ...args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf-8" }).trim();
 }
 
+function runGitWithEnv(cwd: string, env: Record<string, string>, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    env: { ...process.env, ...env },
+  }).trim();
+}
+
 function writeRepoFile(repoPath: string, relativePath: string, content: string): void {
   mkdirSync(dirname(join(repoPath, relativePath)), { recursive: true });
   writeFileSync(join(repoPath, relativePath), content);
@@ -99,6 +107,54 @@ function createCommittedRepo(repoPath: string, files: Record<string, string> = {
   }
   runGit(repoPath, "add", ".");
   runGit(repoPath, "commit", "-m", "init");
+  return repoPath;
+}
+
+function createRepoWithPushedFeatureCommit(
+  repoPath: string,
+  featureBranch: string,
+  initialCommitAt: string,
+  featureCommitAt: string,
+): string {
+  const remotePath = join(tmpDir, `${basename(repoPath)}-remote.git`);
+  mkdirSync(remotePath, { recursive: true });
+  runGit(remotePath, "init", "--bare");
+
+  mkdirSync(repoPath, { recursive: true });
+  runGit(repoPath, "init", "-b", "main");
+  runGit(repoPath, "config", "user.email", "ao@example.com");
+  runGit(repoPath, "config", "user.name", "AO Test");
+  runGit(repoPath, "remote", "add", "origin", remotePath);
+
+  writeRepoFile(repoPath, "README.md", "# test\n");
+  runGit(repoPath, "add", "README.md");
+  runGitWithEnv(
+    repoPath,
+    {
+      GIT_AUTHOR_DATE: initialCommitAt,
+      GIT_COMMITTER_DATE: initialCommitAt,
+    },
+    "commit",
+    "-m",
+    "init",
+  );
+
+  runGit(repoPath, "checkout", "-b", featureBranch);
+  writeRepoFile(repoPath, "feature.txt", "visible progress\n");
+  runGit(repoPath, "add", "feature.txt");
+  runGitWithEnv(
+    repoPath,
+    {
+      GIT_AUTHOR_DATE: featureCommitAt,
+      GIT_COMMITTER_DATE: featureCommitAt,
+    },
+    "commit",
+    "-m",
+    "feat: add visible progress",
+  );
+  runGit(repoPath, "push", "-u", "origin", featureBranch);
+  runGit(repoPath, "fetch", "origin");
+
   return repoPath;
 }
 
@@ -1241,6 +1297,214 @@ describe("check (single session)", () => {
     expect(vi.mocked(mockNotifier.notify).mock.calls.map(([event]) => event.type)).toEqual([
       "reaction.triggered",
     ]);
+  });
+
+  it("marks long-running no-push sessions as stuck when noCommitTimeout is exceeded", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T12:20:01.000Z"));
+
+    config.notificationRouting.urgent = ["desktop"];
+    config.reactions["agent-stuck"] = {
+      auto: true,
+      action: "notify",
+      priority: "urgent",
+      noCommitTimeout: "20m",
+    };
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const repoPath = createCommittedRepo(join(tmpDir, "no-commit-timeout-repo"));
+    runGit(repoPath, "checkout", "-b", "feat/test");
+
+    const createdAt = new Date("2026-03-09T12:00:00.000Z");
+    const session = makeSession({
+      status: "working",
+      pr: null,
+      branch: "feat/test",
+      workspacePath: repoPath,
+      createdAt,
+      metadata: {
+        status: "working",
+        project: "my-app",
+        branch: "feat/test",
+        createdAt: createdAt.toISOString(),
+      },
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: repoPath,
+      branch: "feat/test",
+      status: "working",
+      project: "my-app",
+      createdAt: createdAt.toISOString(),
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("stuck");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("stuck");
+    expect(vi.mocked(mockNotifier.notify).mock.calls.map(([event]) => event.type)).toEqual([
+      "reaction.triggered",
+    ]);
+  });
+
+  it("respects a reset no-commit window after human steering", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T12:20:01.000Z"));
+
+    config.notificationRouting.urgent = ["desktop"];
+    config.reactions["agent-stuck"] = {
+      auto: true,
+      action: "notify",
+      priority: "urgent",
+      noCommitTimeout: "20m",
+    };
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const repoPath = createCommittedRepo(join(tmpDir, "no-commit-reset-repo"));
+    runGit(repoPath, "checkout", "-b", "feat/test");
+
+    const createdAt = new Date("2026-03-09T12:00:00.000Z");
+    const resetAt = new Date("2026-03-09T12:10:30.000Z");
+    const session = makeSession({
+      status: "working",
+      pr: null,
+      branch: "feat/test",
+      workspacePath: repoPath,
+      createdAt,
+      metadata: {
+        status: "working",
+        project: "my-app",
+        branch: "feat/test",
+        createdAt: createdAt.toISOString(),
+        noCommitWindowStartedAt: resetAt.toISOString(),
+      },
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: repoPath,
+      branch: "feat/test",
+      status: "working",
+      project: "my-app",
+      createdAt: createdAt.toISOString(),
+      noCommitWindowStartedAt: resetAt.toISOString(),
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("working");
+    expect(mockNotifier.notify).not.toHaveBeenCalled();
+  });
+
+  it("satisfies noCommitTimeout permanently after a pushed commit is detected", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T12:30:01.000Z"));
+
+    config.notificationRouting.urgent = ["desktop"];
+    config.reactions["agent-stuck"] = {
+      auto: true,
+      action: "notify",
+      priority: "urgent",
+      noCommitTimeout: "20m",
+    };
+
+    const mockNotifier: Notifier = {
+      name: "mock-notifier",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const repoPath = createRepoWithPushedFeatureCommit(
+      join(tmpDir, "no-commit-satisfied-repo"),
+      "feat/test",
+      "2026-03-09T12:00:00Z",
+      "2026-03-09T12:15:00Z",
+    );
+    const createdAt = new Date("2026-03-09T12:10:00.000Z");
+    const session = makeSession({
+      status: "working",
+      pr: null,
+      branch: "feat/test",
+      workspacePath: repoPath,
+      createdAt,
+      metadata: {
+        status: "working",
+        project: "my-app",
+        branch: "feat/test",
+        createdAt: createdAt.toISOString(),
+      },
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: repoPath,
+      branch: "feat/test",
+      status: "working",
+      project: "my-app",
+      createdAt: createdAt.toISOString(),
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("working");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["noCommitSatisfiedAt"]).toBeDefined();
+    expect(mockNotifier.notify).not.toHaveBeenCalled();
   });
 
   it("exempts sessions from maxRuntime once a PR is auto-detected", async () => {

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { chmodSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { execFileSync, spawn } from "node:child_process";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { createSessionManager } from "../session-manager.js";
@@ -44,6 +44,14 @@ function makeHandle(id: string): RuntimeHandle {
 
 function runGit(cwd: string, ...args: string[]): string {
   return execFileSync("git", args, { cwd, encoding: "utf-8" }).trim();
+}
+
+function runGitWithEnv(cwd: string, env: Record<string, string>, ...args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    env: { ...process.env, ...env },
+  }).trim();
 }
 
 function formatErrorMessage(err: unknown): string {
@@ -116,6 +124,54 @@ function installMockOpencodeWithNotFoundDelete(sessionListJson: string): string 
   );
   chmodSync(scriptPath, 0o755);
   return binDir;
+}
+
+function createRepoWithPushedFeatureCommit(
+  repoPath: string,
+  featureBranch: string,
+  initialCommitAt: string,
+  featureCommitAt: string,
+): string {
+  const remotePath = join(tmpDir, `${basename(repoPath)}-remote.git`);
+  mkdirSync(remotePath, { recursive: true });
+  runGit(remotePath, "init", "--bare");
+
+  mkdirSync(repoPath, { recursive: true });
+  runGit(repoPath, "init", "-b", "main");
+  runGit(repoPath, "config", "user.email", "ao@example.com");
+  runGit(repoPath, "config", "user.name", "AO Test");
+  runGit(repoPath, "remote", "add", "origin", remotePath);
+
+  writeFileSync(join(repoPath, "README.md"), "# test\n");
+  runGit(repoPath, "add", "README.md");
+  runGitWithEnv(
+    repoPath,
+    {
+      GIT_AUTHOR_DATE: initialCommitAt,
+      GIT_COMMITTER_DATE: initialCommitAt,
+    },
+    "commit",
+    "-m",
+    "init",
+  );
+
+  runGit(repoPath, "checkout", "-b", featureBranch);
+  writeFileSync(join(repoPath, "feature.txt"), "visible progress\n");
+  runGit(repoPath, "add", "feature.txt");
+  runGitWithEnv(
+    repoPath,
+    {
+      GIT_AUTHOR_DATE: featureCommitAt,
+      GIT_COMMITTER_DATE: featureCommitAt,
+    },
+    "commit",
+    "-m",
+    "feat: add visible progress",
+  );
+  runGit(repoPath, "push", "-u", "origin", featureBranch);
+  runGit(repoPath, "fetch", "origin");
+
+  return repoPath;
 }
 
 beforeEach(() => {
@@ -2187,6 +2243,62 @@ describe("send", () => {
       "Wake up and handle the CI failures",
     );
     expect(readMetadataRaw(sessionsDir, "app-1")?.["status"]).toBe("working");
+  });
+
+  it("resets the no-commit window after a human send when nothing has been pushed yet", async () => {
+    const repoPath = join(tmpDir, "send-reset-no-commit-repo");
+    mkdirSync(repoPath, { recursive: true });
+    runGit(repoPath, "init", "-b", "main");
+    runGit(repoPath, "config", "user.email", "ao@example.com");
+    runGit(repoPath, "config", "user.name", "AO Test");
+    writeFileSync(join(repoPath, "README.md"), "# test\n");
+    runGit(repoPath, "add", "README.md");
+    runGit(repoPath, "commit", "-m", "init");
+    runGit(repoPath, "checkout", "-b", "feat/test");
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: repoPath,
+      branch: "feat/test",
+      status: "working",
+      project: "my-app",
+      createdAt: "2026-03-09T12:00:00.000Z",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+    vi.mocked(mockRuntime.getOutput).mockResolvedValueOnce("before").mockResolvedValueOnce("after");
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await sm.send("app-1", "Please push your first commit", { resetNoCommitTimeout: true });
+
+    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["status"]).toBe("working");
+    expect(metadata?.["noCommitWindowStartedAt"]).toBeDefined();
+    expect(metadata?.["noCommitSatisfiedAt"]).toBeUndefined();
+  });
+
+  it("preserves no-commit satisfaction after a human send when a pushed commit already exists", async () => {
+    const repoPath = createRepoWithPushedFeatureCommit(
+      join(tmpDir, "send-reset-pushed-commit-repo"),
+      "feat/test",
+      "2026-03-09T12:00:00Z",
+      "2026-03-09T12:15:00Z",
+    );
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: repoPath,
+      branch: "feat/test",
+      status: "working",
+      project: "my-app",
+      createdAt: "2026-03-09T12:10:00.000Z",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+    vi.mocked(mockRuntime.getOutput).mockResolvedValueOnce("before").mockResolvedValueOnce("after");
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await sm.send("app-1", "Please keep going", { resetNoCommitTimeout: true });
+
+    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    expect(metadata?.["status"]).toBe("working");
+    expect(metadata?.["noCommitSatisfiedAt"]).toBeDefined();
   });
 
   it("prefers a live session over stale terminal metadata when sending", async () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -86,6 +86,7 @@ const ReactionConfigSchema = z.object({
   escalateAfter: z.union([z.number(), z.string()]).optional(),
   threshold: z.string().optional(),
   maxRuntime: z.string().optional(),
+  noCommitTimeout: z.string().optional(),
   firstCommit: z.string().optional(),
   firstPR: z.string().optional(),
   checkpointMessage: z.string().optional(),

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -647,6 +647,14 @@ async function runGitProgressCommand(args: string[], cwd: string): Promise<strin
   }
 }
 
+async function countPushedCommitsSince(workspacePath: string, sinceIso: string): Promise<number> {
+  const output = await runGitProgressCommand(
+    ["rev-list", "--count", `--since=${sinceIso}`, "@{u}"],
+    workspacePath,
+  );
+  return output ? Math.max(0, Number.parseInt(output, 10) || 0) : 0;
+}
+
 function parseDirtyFiles(output: string | null): string[] {
   if (!output) return [];
 
@@ -1653,6 +1661,36 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     return Date.now() - createdAtMs > maxRuntimeMs;
   }
 
+  /** Check if a session has gone too long without a pushed commit. */
+  async function isBeyondNoCommitTimeout(session: Session): Promise<boolean> {
+    const noCommitTimeoutStr = getAgentStuckReactionConfig(session)?.noCommitTimeout;
+    if (typeof noCommitTimeoutStr !== "string") return false;
+    const noCommitTimeoutMs = parseDuration(noCommitTimeoutStr);
+    if (noCommitTimeoutMs <= 0) return false;
+    if (typeof session.metadata["noCommitSatisfiedAt"] === "string") return false;
+    if (!session.workspacePath) return false;
+
+    const createdAtMs = session.createdAt.getTime();
+    if (!Number.isFinite(createdAtMs)) return false;
+
+    const windowStartedAtMs = Math.max(
+      parseTimestampMs(session.metadata["noCommitWindowStartedAt"]) ?? createdAtMs,
+      createdAtMs,
+    );
+    if (Date.now() - windowStartedAtMs <= noCommitTimeoutMs) return false;
+
+    const pushedCommitsSinceWindow = await countPushedCommitsSince(
+      session.workspacePath,
+      new Date(windowStartedAtMs).toISOString(),
+    );
+    if (pushedCommitsSinceWindow > 0) {
+      updateSessionMetadata(session, { noCommitSatisfiedAt: new Date().toISOString() });
+      return false;
+    }
+
+    return true;
+  }
+
   async function evaluateOpenPR(
     session: Session,
     scm: SCM,
@@ -2006,6 +2044,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     if (preserveCurrentStatus) {
       return currentStatus;
+    }
+
+    if (!session.pr && (await isBeyondNoCommitTimeout(session))) {
+      return SESSION_STATUS.STUCK;
     }
 
     if (!session.pr && isBeyondMaxRuntime(session)) {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -113,6 +113,12 @@ export function readMetadata(dataDir: string, sessionId: SessionId): SessionMeta
       ? Number(raw["directTerminalWsPort"])
       : undefined,
     opencodeSessionId: raw["opencodeSessionId"],
+    progressCheckpointResetAt: raw["progressCheckpointResetAt"],
+    progressCheckpointMissCount: raw["progressCheckpointMissCount"],
+    progressCheckpointFirstCommitFiredAt: raw["progressCheckpointFirstCommitFiredAt"],
+    progressCheckpointFirstPRFiredAt: raw["progressCheckpointFirstPRFiredAt"],
+    noCommitWindowStartedAt: raw["noCommitWindowStartedAt"],
+    noCommitSatisfiedAt: raw["noCommitSatisfiedAt"],
   };
 }
 
@@ -182,6 +188,17 @@ export function writeMetadata(
   if (metadata.directTerminalWsPort !== undefined)
     data["directTerminalWsPort"] = String(metadata.directTerminalWsPort);
   if (metadata.opencodeSessionId) data["opencodeSessionId"] = metadata.opencodeSessionId;
+  if (metadata.progressCheckpointResetAt)
+    data["progressCheckpointResetAt"] = metadata.progressCheckpointResetAt;
+  if (metadata.progressCheckpointMissCount)
+    data["progressCheckpointMissCount"] = metadata.progressCheckpointMissCount;
+  if (metadata.progressCheckpointFirstCommitFiredAt)
+    data["progressCheckpointFirstCommitFiredAt"] = metadata.progressCheckpointFirstCommitFiredAt;
+  if (metadata.progressCheckpointFirstPRFiredAt)
+    data["progressCheckpointFirstPRFiredAt"] = metadata.progressCheckpointFirstPRFiredAt;
+  if (metadata.noCommitWindowStartedAt)
+    data["noCommitWindowStartedAt"] = metadata.noCommitWindowStartedAt;
+  if (metadata.noCommitSatisfiedAt) data["noCommitSatisfiedAt"] = metadata.noCommitSatisfiedAt;
 
   atomicWriteFileSync(path, serializeMetadata(data));
 }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -43,6 +43,7 @@ import {
   type PluginRegistry,
   type RuntimeHandle,
   type Issue,
+  type SendSessionOptions,
   PR_STATE,
 } from "./types.js";
 import {
@@ -89,6 +90,7 @@ const PROCESS_TERMINATION_TIMEOUT_MS = 5_000;
 const PROCESS_TERMINATION_POLL_MS = 200;
 const TMUX_KILL_TIMEOUT_MS = 5_000;
 const GIT_CLEANUP_TIMEOUT_MS = 30_000;
+const GIT_PROGRESS_TIMEOUT_MS = 5_000;
 
 interface ProcessSnapshot {
   pid: number;
@@ -110,6 +112,23 @@ function getExitCode(err: unknown): number | null {
 
 function formatError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+async function countPushedCommitsSince(workspacePath: string, sinceIso: string): Promise<number> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["rev-list", "--count", `--since=${sinceIso}`, "@{u}"],
+      {
+        cwd: workspacePath,
+        timeout: GIT_PROGRESS_TIMEOUT_MS,
+        maxBuffer: 1024 * 1024,
+      },
+    );
+    return Math.max(0, Number.parseInt(stdout.trim(), 10) || 0);
+  } catch {
+    return 0;
+  }
 }
 
 function emitKillStep(
@@ -2154,7 +2173,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     return result;
   }
 
-  async function send(sessionId: SessionId, message: string): Promise<void> {
+  async function send(
+    sessionId: SessionId,
+    message: string,
+    options?: SendSessionOptions,
+  ): Promise<void> {
     const { raw, sessionsDir, project } = requireSessionRecord(sessionId);
     const persistedStatus = validateStatus(raw["status"]);
     const pause = getProjectPause(project);
@@ -2365,10 +2388,37 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
     }
 
+    const metadataUpdates: Partial<Record<string, string>> = {};
+
     // A freshly delivered prompt means the session is actively working again,
     // even if the last persisted status was idle/stuck/review-related.
     if (!NON_RESTORABLE_STATUSES.has(persistedStatus)) {
-      updateMetadata(sessionsDir, sessionId, { status: "working" });
+      metadataUpdates["status"] = "working";
+    }
+
+    if (options?.resetNoCommitTimeout) {
+      const resetAt = new Date().toISOString();
+      const createdAtMs = raw["createdAt"] ? Date.parse(raw["createdAt"]) : Number.NaN;
+      const workspacePath = raw["worktree"];
+
+      if (workspacePath && Number.isFinite(createdAtMs)) {
+        const pushedCommitsSinceSpawn = await countPushedCommitsSince(
+          workspacePath,
+          new Date(createdAtMs).toISOString(),
+        );
+
+        if (pushedCommitsSinceSpawn > 0) {
+          metadataUpdates["noCommitSatisfiedAt"] = resetAt;
+        } else {
+          metadataUpdates["noCommitWindowStartedAt"] = resetAt;
+        }
+      } else {
+        metadataUpdates["noCommitWindowStartedAt"] = resetAt;
+      }
+    }
+
+    if (Object.keys(metadataUpdates).length > 0) {
+      updateMetadata(sessionsDir, sessionId, metadataUpdates);
     }
   }
 
@@ -2577,6 +2627,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         createdAt: raw["createdAt"],
         runtimeHandle: raw["runtimeHandle"],
         opencodeSessionId: raw["opencodeSessionId"],
+        progressCheckpointResetAt: raw["progressCheckpointResetAt"],
+        progressCheckpointMissCount: raw["progressCheckpointMissCount"],
+        progressCheckpointFirstCommitFiredAt: raw["progressCheckpointFirstCommitFiredAt"],
+        progressCheckpointFirstPRFiredAt: raw["progressCheckpointFirstPRFiredAt"],
+        noCommitWindowStartedAt: raw["noCommitWindowStartedAt"],
+        noCommitSatisfiedAt: raw["noCommitSatisfiedAt"],
       });
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -979,6 +979,9 @@ export interface ReactionConfig {
   /** Maximum session age before agent-stuck fires when no PR exists (e.g. "30m") */
   maxRuntime?: string;
 
+  /** Maximum time without a pushed commit before agent-stuck fires (e.g. "20m") */
+  noCommitTimeout?: string;
+
   /** Progress checkpoint threshold for the first pushed commit (e.g. "15m") */
   firstCommit?: string;
 
@@ -1412,6 +1415,8 @@ export interface SessionMetadata {
   progressCheckpointMissCount?: string;
   progressCheckpointFirstCommitFiredAt?: string;
   progressCheckpointFirstPRFiredAt?: string;
+  noCommitWindowStartedAt?: string;
+  noCommitSatisfiedAt?: string;
 }
 
 // =============================================================================
@@ -1430,8 +1435,13 @@ export interface SessionManager {
     projectId?: string,
     options?: { dryRun?: boolean; purgeOpenCode?: boolean },
   ): Promise<CleanupResult>;
-  send(sessionId: SessionId, message: string): Promise<void>;
+  send(sessionId: SessionId, message: string, options?: SendSessionOptions): Promise<void>;
   claimPR(sessionId: SessionId, prRef: string, options?: ClaimPROptions): Promise<ClaimPRResult>;
+}
+
+export interface SendSessionOptions {
+  /** Reset the no-commit timeout window after a human steering action. */
+  resetNoCommitTimeout?: boolean;
 }
 
 /** OpenCode-specific session manager with remap capability */

--- a/syntese.yaml.example
+++ b/syntese.yaml.example
@@ -184,5 +184,6 @@ projects:
 #
 #   agent-stuck:
 #     threshold: 10m
+#     noCommitTimeout: 20m
 #     action: notify
 #     priority: urgent


### PR DESCRIPTION
## Summary
- add `noCommitTimeout` to `agent-stuck` reactions
- mark sessions stuck when no pushed commit is observed before the timeout, with the window resetting on human steering
- cover the new behavior in core and CLI tests and document the config option

## Testing
- pnpm run typecheck
- pnpm test
- pnpm run lint

Closes #72