### PR TITLE
fix: add token-based usage estimation when rate_limit_event is absent

### DIFF
--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -707,9 +707,115 @@ describe("getUsageSnapshot", () => {
     ]);
   });
 
-  it("returns null when no rate_limit_event lines exist", async () => {
+  it("returns null when no rate_limit_event lines exist and no usage data", async () => {
     mockJsonlFiles('{"type":"assistant","message":{"content":"done"}}');
     expect(await agent.getUsageSnapshot!(makeSession())).toBeNull();
+  });
+
+  describe("token-based fallback (no rate_limit_event)", () => {
+    it("returns estimated snapshot with current-session token dial from message.usage", async () => {
+      const jsonl = [
+        '{"type":"user","message":{"content":"write a function"}}',
+        '{"timestamp":"2026-03-10T12:00:00.000Z","type":"assistant","message":{"role":"assistant","content":"here you go","usage":{"input_tokens":500,"output_tokens":1200,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}',
+      ].join("\n");
+
+      mockJsonlFiles(jsonl);
+
+      const snapshot = await agent.getUsageSnapshot!(makeSession());
+
+      expect(snapshot).not.toBeNull();
+      expect(snapshot?.provider).toBe("claude-code");
+      expect(snapshot?.dials.some((d) => d.id === "claude-current-session")).toBe(true);
+      const sessionDial = snapshot?.dials.find((d) => d.id === "claude-current-session");
+      expect(sessionDial?.kind).toBe("absolute");
+      expect(sessionDial?.value).toBe(1200);
+      expect(sessionDial?.isEstimated).toBe(true);
+      expect(sessionDial?.displayValue).toContain("out");
+    });
+
+    it("sums output tokens across multiple assistant messages", async () => {
+      const jsonl = [
+        '{"timestamp":"2026-03-10T11:00:00.000Z","type":"assistant","message":{"role":"assistant","content":"a","usage":{"input_tokens":100,"output_tokens":300}}}',
+        '{"timestamp":"2026-03-10T11:30:00.000Z","type":"assistant","message":{"role":"assistant","content":"b","usage":{"input_tokens":200,"output_tokens":700}}}',
+      ].join("\n");
+
+      mockJsonlFiles(jsonl);
+
+      const snapshot = await agent.getUsageSnapshot!(makeSession());
+      const sessionDial = snapshot?.dials.find((d) => d.id === "claude-current-session");
+
+      expect(sessionDial?.value).toBe(1000);
+    });
+
+    it("also accepts top-level outputTokens field", async () => {
+      const jsonl = [
+        '{"timestamp":"2026-03-10T12:00:00.000Z","type":"assistant","outputTokens":450}',
+      ].join("\n");
+
+      mockJsonlFiles(jsonl);
+
+      const snapshot = await agent.getUsageSnapshot!(makeSession());
+      const sessionDial = snapshot?.dials.find((d) => d.id === "claude-current-session");
+
+      expect(sessionDial?.value).toBe(450);
+      expect(sessionDial?.isEstimated).toBe(true);
+    });
+
+    it("includes weekly dials when stats-cache.json has data", async () => {
+      const sessionJsonl = [
+        '{"timestamp":"2026-03-10T12:00:00.000Z","type":"assistant","message":{"role":"assistant","content":"ok","usage":{"input_tokens":100,"output_tokens":500}}}',
+      ].join("\n");
+
+      const statsCache = JSON.stringify({
+        version: 2,
+        lastComputedDate: "2026-03-10",
+        dailyModelTokens: [
+          { date: "2026-03-08", tokensByModel: { "claude-sonnet-4-6": 1500, "claude-opus-4-6": 800 } },
+          { date: "2026-03-10", tokensByModel: { "claude-sonnet-4-6": 2000 } },
+        ],
+      });
+
+      // First call (readFile for JSONL file), subsequent calls return stats cache
+      mockReaddir.mockResolvedValue(["session-abc123.jsonl"]);
+      mockStat.mockResolvedValue({ mtimeMs: 1000, mtime: new Date(1000) });
+      mockReadFile.mockImplementation(async (path: string) => {
+        if (typeof path === "string" && path.includes("stats-cache")) {
+          return statsCache;
+        }
+        return sessionJsonl;
+      });
+
+      const snapshot = await agent.getUsageSnapshot!(makeSession());
+
+      expect(snapshot).not.toBeNull();
+      const weeklyAllDial = snapshot?.dials.find((d) => d.id === "claude-weekly-all-models");
+      const weeklySonnetDial = snapshot?.dials.find((d) => d.id === "claude-weekly-sonnet-only");
+
+      expect(weeklyAllDial).toBeDefined();
+      expect(weeklyAllDial?.kind).toBe("absolute");
+      expect(weeklyAllDial?.value).toBe(4300); // 1500+800+2000
+      expect(weeklyAllDial?.isEstimated).toBe(true);
+
+      expect(weeklySonnetDial).toBeDefined();
+      expect(weeklySonnetDial?.value).toBe(3500); // 1500+2000
+    });
+
+    it("rate_limit_event takes priority over token-based fallback", async () => {
+      const jsonl = [
+        '{"timestamp":"2026-03-10T12:00:00.000Z","type":"assistant","message":{"role":"assistant","content":"a","usage":{"output_tokens":999}}}',
+        '{"timestamp":"2026-03-10T12:00:01.000Z","type":"rate_limit_event","rate_limit_info":{"rateLimitType":"five_hour","utilization":0.25,"resetsAt":"2026-03-10T15:00:00.000Z"}}',
+      ].join("\n");
+
+      mockJsonlFiles(jsonl);
+
+      const snapshot = await agent.getUsageSnapshot!(makeSession());
+
+      // Should use rate_limit_event data (percent_used), not token fallback (absolute)
+      const sessionDial = snapshot?.dials.find((d) => d.id === "claude-current-session");
+      expect(sessionDial?.kind).toBe("percent_used");
+      expect(sessionDial?.value).toBe(25);
+      expect(sessionDial?.isEstimated).toBeFalsy();
+    });
   });
 
   it("falls back to the canonical workspace path for worktree sessions", async () => {

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -302,7 +302,17 @@ interface JsonlLine {
   timestamp?: string;
   type?: string;
   summary?: string;
-  message?: { content?: string; role?: string };
+  message?: {
+    content?: string | unknown[];
+    role?: string;
+    /** Token usage data present on assistant messages (Claude v2.x session format) */
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
+    };
+  };
   // Cost/usage fields
   costUSD?: number;
   usage?: {
@@ -548,6 +558,165 @@ function extractUsageSnapshot(lines: JsonlLine[]): UsageSnapshot | null {
 
   if (dials.length === 0) {
     return null;
+  }
+
+  return {
+    provider: "claude-code",
+    plan: null,
+    capturedAt: capturedAt ?? new Date().toISOString(),
+    dials,
+  };
+}
+
+// =============================================================================
+// Token-Based Usage Estimation (fallback when rate_limit_event is absent)
+// =============================================================================
+
+interface DailyModelTokens {
+  date: string;
+  tokensByModel: Record<string, number>;
+}
+
+interface StatsCache {
+  dailyModelTokens?: DailyModelTokens[];
+}
+
+function formatTokenCount(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}K`;
+  return String(tokens);
+}
+
+async function readClaudeStatsCache(): Promise<StatsCache | null> {
+  try {
+    const cachePath = join(homedir(), ".claude", "stats-cache.json");
+    const raw = await readFile(cachePath, "utf-8");
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    return parsed as StatsCache;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compute total tokens from the stats cache for the past 7 days.
+ * Optionally filters to Sonnet-family models only.
+ */
+function computeWeeklyTokensFromCache(cache: StatsCache | null, sonnetOnly: boolean): number {
+  if (!cache?.dailyModelTokens) return 0;
+
+  const sevenDaysAgo = new Date();
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+  const cutoff = sevenDaysAgo.toISOString().slice(0, 10);
+
+  let total = 0;
+  for (const entry of cache.dailyModelTokens) {
+    if (entry.date < cutoff) continue;
+    for (const [model, tokens] of Object.entries(entry.tokensByModel)) {
+      if (sonnetOnly && !model.toLowerCase().includes("sonnet")) continue;
+      total += typeof tokens === "number" ? tokens : 0;
+    }
+  }
+  return total;
+}
+
+/**
+ * Count output tokens from assistant messages in the parsed JSONL lines.
+ * Claude Code v2.x stores usage inside `message.usage` on assistant entries.
+ */
+function countSessionOutputTokens(lines: JsonlLine[]): number {
+  let total = 0;
+  for (const line of lines) {
+    // Primary: message.usage on assistant messages (Claude v2.x format)
+    const msgUsage = line.message?.usage;
+    if (msgUsage && typeof msgUsage.output_tokens === "number") {
+      total += msgUsage.output_tokens;
+      continue;
+    }
+    // Fallback: top-level usage field (older format)
+    if (line.usage && typeof line.usage.output_tokens === "number") {
+      total += line.usage.output_tokens;
+      continue;
+    }
+    // Flat outputTokens
+    if (typeof line.outputTokens === "number") {
+      total += line.outputTokens;
+    }
+  }
+  return total;
+}
+
+/**
+ * Build a token-count-based usage snapshot when no rate_limit_event entries
+ * are present in the session JSONL. This happens in interactive Claude Code
+ * sessions (rate_limit_event is only emitted in streaming/print mode).
+ *
+ * Returns absolute-kind dials with token counts. The values are estimates
+ * (marked isEstimated: true) since we don't know the exact subscription limits.
+ */
+async function extractTokenBasedSnapshot(lines: JsonlLine[]): Promise<UsageSnapshot | null> {
+  const sessionOutputTokens = countSessionOutputTokens(lines);
+  if (sessionOutputTokens === 0) {
+    return null;
+  }
+
+  let capturedAt: string | null = null;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (typeof lines[i]?.timestamp === "string") {
+      capturedAt = lines[i]!.timestamp!;
+      break;
+    }
+  }
+
+  const dials: UsageDial[] = [
+    {
+      id: "claude-current-session",
+      label: "Current session usage",
+      kind: "absolute",
+      status: "available",
+      value: sessionOutputTokens,
+      maxValue: null,
+      displayValue: formatTokenCount(sessionOutputTokens) + " out",
+      isEstimated: true,
+      estimationConfidence: 0.3,
+      resetsAt: null,
+    },
+  ];
+
+  // Add weekly dials from the stats cache if available.
+  const statsCache = await readClaudeStatsCache();
+  const weeklyAllModels = computeWeeklyTokensFromCache(statsCache, false);
+  const weeklySonnet = computeWeeklyTokensFromCache(statsCache, true);
+
+  if (weeklyAllModels > 0) {
+    dials.push({
+      id: "claude-weekly-all-models",
+      label: "Weekly limits - All models",
+      kind: "absolute",
+      status: "available",
+      value: weeklyAllModels,
+      maxValue: null,
+      displayValue: formatTokenCount(weeklyAllModels) + " tokens",
+      isEstimated: true,
+      estimationConfidence: 0.3,
+      resetsAt: null,
+    });
+  }
+
+  if (weeklySonnet > 0) {
+    dials.push({
+      id: "claude-weekly-sonnet-only",
+      label: "Weekly limits - Sonnet only",
+      kind: "absolute",
+      status: "available",
+      value: weeklySonnet,
+      maxValue: null,
+      displayValue: formatTokenCount(weeklySonnet) + " tokens",
+      isEstimated: true,
+      estimationConfidence: 0.3,
+      resetsAt: null,
+    });
   }
 
   return {
@@ -955,7 +1124,16 @@ function createClaudeCodeAgent(): Agent {
       const lines = await parseJsonlFileTail(sessionFile);
       if (lines.length === 0) return null;
 
-      return extractUsageSnapshot(lines);
+      // Primary: look for rate_limit_event entries (precise subscription data
+      // emitted by Claude Code in streaming/print mode).
+      const rateLimitSnapshot = extractUsageSnapshot(lines);
+      if (rateLimitSnapshot) return rateLimitSnapshot;
+
+      // Fallback: compute token-based estimates from assistant message usage.
+      // Interactive Claude Code sessions store usage inside message.usage rather
+      // than emitting rate_limit_event entries, so this fallback ensures the
+      // dashboard always shows data when sessions are active.
+      return extractTokenBasedSnapshot(lines);
     },
 
     async getRestoreCommand(session: Session, project: ProjectConfig): Promise<string | null> {

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -1195,7 +1195,7 @@ describe("getUsageSnapshot", () => {
     expect(snapshot?.dials[0]?.displayValue).toBe("80%");
   });
 
-  it("returns null when no rate-limit payloads are present", async () => {
+  it("returns token-count fallback snapshot when rate-limit payloads are null but tokens exist", async () => {
     const sessionContent = jsonl(
       { type: "session_meta", cwd: "/workspace/test", model: "gpt-5-codex" },
       {
@@ -1209,6 +1209,30 @@ describe("getUsageSnapshot", () => {
           rate_limits: null,
         },
       },
+    );
+
+    mockReaddir.mockResolvedValue(["rollout-456.jsonl"]);
+    setupMockOpen(sessionContent);
+    setupMockStream(sessionContent);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const snapshot = await agent.getUsageSnapshot!(
+      makeSession({ workspacePath: "/workspace/test" }),
+    );
+
+    // Should fall back to token-count dial rather than returning null
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.provider).toBe("codex");
+    const tokenDial = snapshot?.dials.find((d) => d.id === "codex-5h");
+    expect(tokenDial).toBeDefined();
+    expect(tokenDial?.kind).toBe("absolute");
+    expect(tokenDial?.value).toBe(1250); // input + output tokens
+    expect(tokenDial?.isEstimated).toBe(true);
+  });
+
+  it("returns null when no rate-limit payloads and no token data", async () => {
+    const sessionContent = jsonl(
+      { type: "session_meta", cwd: "/workspace/test", model: "gpt-5-codex" },
     );
 
     mockReaddir.mockResolvedValue(["rollout-456.jsonl"]);

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -709,6 +709,12 @@ function formatCredits(balance: number): string {
   }).format(displayBalance);
 }
 
+function formatTokenCount(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}K`;
+  return String(tokens);
+}
+
 function formatPlanType(planType: string | null): string | null {
   if (!planType) return null;
   if (planType.toLowerCase() === "pro") {
@@ -739,7 +745,31 @@ function createPercentRemainingDial(
 
 function buildCodexUsageSnapshot(data: CodexSessionData): UsageSnapshot | null {
   if (data.rateLimits.size === 0 && !data.credits) {
-    return null;
+    // Fallback: no rate-limit data at all, but we may still have token counts.
+    // Emit an estimated dial so the dashboard moves out of the "AWAITING FIRST
+    // SNAPSHOT" state even when the Codex API omits rate-limit fields.
+    const totalTokens = data.inputTokens + data.outputTokens;
+    if (totalTokens === 0) {
+      return null;
+    }
+    return {
+      provider: "codex",
+      plan: formatPlanType(data.plan),
+      capturedAt: data.capturedAt ?? new Date().toISOString(),
+      dials: [
+        {
+          id: "codex-5h",
+          label: "5 hour usage limit",
+          kind: "absolute",
+          status: "available",
+          value: totalTokens,
+          maxValue: null,
+          displayValue: formatTokenCount(totalTokens) + " tokens",
+          isEstimated: true,
+          resetsAt: null,
+        },
+      ],
+    };
   }
 
   const dials = new Map<string, UsageDial>();
@@ -831,7 +861,27 @@ function buildCodexUsageSnapshot(data: CodexSessionData): UsageSnapshot | null {
   }
 
   if (dials.size === 0) {
-    return null;
+    // Fallback: no rate-limit data was populated (primary field values are null),
+    // but we may still have token-count data from the session. Emit an estimated
+    // dial so the dashboard moves out of the "AWAITING FIRST SNAPSHOT" state.
+    const totalTokens = data.inputTokens + data.outputTokens;
+    if (totalTokens > 0) {
+      dials.set("codex-5h", {
+        id: "codex-5h",
+        label: "5 hour usage limit",
+        kind: "absolute",
+        status: "available",
+        value: totalTokens,
+        maxValue: null,
+        displayValue: formatTokenCount(totalTokens) + " tokens",
+        isEstimated: true,
+        resetsAt: null,
+      });
+    }
+
+    if (dials.size === 0) {
+      return null;
+    }
   }
 
   const order = [


### PR DESCRIPTION
## Summary

- **Root cause**: Usage dials permanently showed "AWAITING FIRST SNAPSHOT" because `getUsageSnapshot()` always returned `null` for both plugins. Claude Code interactive sessions store conversation history in JSONL files that contain `message.usage` on assistant entries, but do NOT emit `rate_limit_event` entries (those only appear in `--print`/streaming mode). Codex sessions emit `rate_limits` objects but with all-null fields when the API omits rate data.
- **Claude Code fix**: Added a token-count fallback in `agent-claude-code`. When no `rate_limit_event` entries are found, count `output_tokens` from `message.usage` on assistant entries and return an estimated `absolute`-kind "current session" dial. Also reads `~/.claude/stats-cache.json` for weekly all-models and Sonnet-only token totals. All fallback dials are marked `isEstimated: true`.
- **Codex fix**: When `rateLimits` is empty or all `primary` fields are null, fall back to a token-count dial combining `inputTokens + outputTokens`. Also marked `isEstimated: true`.
- The existing `rate_limit_event` parsing path remains the primary source and takes precedence when present (delivers exact subscription percentages).

## What changes

- `packages/plugins/agent-claude-code/src/index.ts`: extend `JsonlLine.message` to capture `usage`; add `StatsCache` reader, `countSessionOutputTokens`, `extractTokenBasedSnapshot` fallback; update `getUsageSnapshot` to call it.
- `packages/plugins/agent-codex/src/index.ts`: add `formatTokenCount` helper; update `buildCodexUsageSnapshot` with two token-count fallback paths (empty rateLimits and null-primary rateLimits).
- Tests updated/added for both plugins covering the new fallback behaviour.

## Test plan

- [ ] All plugin tests pass: `pnpm test` in `agent-claude-code` and `agent-codex`
- [ ] Start a Claude Code session, open dashboard — dials should show token counts instead of "AWAITING FIRST SNAPSHOT"
- [ ] Start a Codex session — similar improvement
- [ ] If a session emits `rate_limit_event` entries, those exact percentages are shown (not the token estimate)
- [ ] `isEstimated: true` on fallback dials shows the "Estimated" badge in the UI

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)