### PR TITLE
docs: add hierarchical AGENTS.md knowledge base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,5 @@ agent-orchestrator.yaml
 
 # Agent configuration and tracking (personal, not for repo)
 CLAUDE.md
-AGENTS.md
 .claude/
 .opencode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# SYNTESE — PROJECT KNOWLEDGE BASE
+
+**Generated:** 2026-03-11 | **Commit:** e6426d7 | **Branch:** main
+
+## OVERVIEW
+
+AI agent orchestration platform. Spawns parallel coding agents (Claude Code, Codex, Aider, OpenCode) in isolated git worktrees, monitors PR lifecycle, auto-reacts to CI failures and review comments. pnpm monorepo, TypeScript strict, Node 20+.
+
+## STRUCTURE
+
+```
+syntese/
+├── packages/
+│   ├── core/              # Engine: types, session manager, lifecycle, plugins
+│   ├── cli/               # CLI: `syn` (aliases: `syntese`, `ao`) — Commander.js
+│   ├── web/               # Dashboard: Next.js 15 + terminal WebSocket servers
+│   ├── syntese/           # Global bin wrapper re-exporting @syntese/cli
+│   ├── mobile/            # React Native app (EXCLUDED from pnpm workspace)
+│   ├── integration-tests/ # E2E tests for all plugins (vitest forks pool)
+│   └── plugins/           # 20 plugin packages across 8 slots
+├── scripts/               # Legacy bash helpers (claude-spawn, notify-session, etc.)
+├── docs/                  # Design docs, security audit, dev guide
+├── examples/              # Config templates (GitHub, Linear, multi-project)
+├── tests/integration/     # Docker-based onboarding test
+└── .github/workflows/     # 8 CI workflows (ci, security, integration, release)
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+|------|----------|-------|
+| Add CLI command | `packages/cli/src/commands/` | Register in `program.ts`, follow Commander pattern |
+| Add plugin | `packages/plugins/{slot}-{name}/` | Implement interface from `core/types.ts`, export `PluginModule` |
+| Change session lifecycle | `packages/core/src/lifecycle-manager.ts` | 117KB — the central state machine |
+| Modify dashboard UI | `packages/web/src/components/` | React 19 + Tailwind v4, server-rendered via App Router |
+| Add API endpoint | `packages/web/src/app/api/` | Next.js route handlers, init services via `lib/services.ts` |
+| Terminal WebSocket | `packages/web/server/` | Two backends: ttyd-based + direct node-pty |
+| Config schema | `packages/core/src/config.ts` | Zod validation, loads `syntese.yaml` |
+| Type definitions | `packages/core/src/types.ts` | ALL plugin interfaces (1591 lines) — the contract |
+| Session metadata | `packages/core/src/metadata.ts` | Flat-file key=value in `~/.syntese/` |
+| Integration tests | `packages/integration-tests/src/` | `.integration.test.ts` suffix, requires tmux + agent binaries |
+| Recovery logic | `packages/core/src/recovery/` | Session crash detection + auto-restore |
+| Account/quota | `packages/core/src/account-capacity.ts` | Multi-account with per-window quota tracking |
+
+## CONVENTIONS
+
+- **Module system**: ESM only (`"type": "module"`). Use `.js` extensions in imports (`import "./foo.js"`)
+- **Type imports**: `import type { X }` enforced by ESLint (`consistent-type-imports`)
+- **No any**: `@typescript-eslint/no-explicit-any` is error (relaxed in tests only)
+- **Prettier**: 100-char width, double quotes, trailing commas, semicolons
+- **Tests**: Vitest everywhere. Unit in `__tests__/`, integration in separate package with `.integration.test.ts`
+- **Unused vars**: Prefix with `_` (e.g., `_unused`) — enforced
+- **Plugin naming**: `@syntese/plugin-{slot}-{name}` (e.g., `plugin-agent-claude-code`)
+- **Session naming**: `{prefix}-{num}` user-facing, `{hash}-{prefix}-{num}` for tmux (global uniqueness)
+- **No database**: All state in flat-file metadata (`~/.syntese/{hash}-{project}/sessions/`)
+- **Changesets**: Version management via `@changesets/cli`, not manual
+
+## GIT WORKFLOW (MANDATORY)
+
+- **NEVER** commit directly to `main` or `dev`
+- For every task: create a worktree (`git worktree add ../wt-<branch> -b feat/<name>`)
+- Work ONLY inside the worktree directory
+- When done: commit, push, open PR via `gh pr create`
+- After PR is merged: clean up worktree (`git worktree remove`)
+- Commit messages: conventional commits (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`)
+
+## ANTI-PATTERNS
+
+- **NEVER** commit secrets — pre-commit gitleaks hook blocks it. Use `.env.local`
+- **NEVER** use `eval()`, `new Function()`, or `require()` — ESLint errors
+- **NEVER** suppress types with `as any` or `@ts-ignore`
+- **NEVER** put console.log in core/plugin packages — only CLI and web are exempted
+- **NEVER** skip the hash prefix in tmux session names — causes cross-instance collisions
+- Orchestrator sessions ALWAYS get `permissionless` mode — non-negotiable for autonomous CLI execution
+- `lifecycle-manager.ts` is monolithic by design — do NOT split it
+
+## COMMANDS
+
+```bash
+pnpm install && pnpm build     # Install + build all packages
+pnpm dev                        # Start web dashboard (Next.js + terminal WS servers)
+pnpm test                       # Unit tests (excludes web package)
+pnpm test:integration           # Integration tests (requires tmux, agent binaries)
+pnpm lint                       # ESLint
+pnpm format:check               # Prettier check
+pnpm typecheck                  # TypeScript check (all packages)
+```
+
+## NOTES
+
+- `AGENTS.md` and `CLAUDE.md` are gitignored — local knowledge bases only
+- `packages/mobile` excluded from workspace — builds separately with Expo
+- `postinstall` runs `scripts/rebuild-node-pty.js` — node-pty requires native rebuild
+- Web tests excluded from root `pnpm test` — run separately via `pnpm --filter @syntese/web test`
+- `syntese.yaml` (runtime config) is gitignored — use `syntese.yaml.example` as template
+- Terminal WS auth is TODO — currently basic CORS only, not production-ready
+- AI-powered rule generation in `init` command is stub — template-based only
+- Two terminal backends exist: ttyd (iframe, port 14800) and direct WS (node-pty, port 14801)
+- `.cursor/` dir exists — some team members use Cursor IDE

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -1,0 +1,54 @@
+# @syntese/cli
+
+User-facing CLI. Triple-aliased as `syn`, `syntese`, `ao`. Built with Commander.js.
+
+## STRUCTURE
+
+```
+src/
+├── index.ts        # Entry point (shebang, calls createProgram().parse())
+├── program.ts      # Commander setup, registers all commands
+├── commands/       # One file per command group (14 commands)
+│   ├── spawn.ts        # Spawn agent session
+│   ├── start.ts        # Start orchestrator + dashboard
+│   ├── init.ts         # Initialize project (auto-detect + config gen)
+│   ├── session.ts      # ls, kill, restore, claim-pr
+│   ├── send.ts         # Send instructions to running agent
+│   ├── status.ts       # Overview of all sessions
+│   ├── services.ts     # Supervised runtime (systemd/supervisor)
+│   ├── dashboard.ts    # Open/start web dashboard
+│   ├── accounts.ts     # Account management (login, test, status)
+│   ├── capacity.ts     # Quota monitoring
+│   ├── open.ts         # Open session in terminal
+│   ├── verify.ts       # Post-push verification
+│   ├── review-check.ts # PR review status
+│   └── lifecycle-worker.ts  # Background lifecycle polling
+└── lib/            # Shared CLI utilities (13 modules)
+    ├── create-session-manager.ts  # Factory: loads config → plugins → SessionManager
+    ├── plugins.ts                 # Plugin loading + registration
+    ├── services.ts                # Service management (systemd/supervisor, 25KB)
+    ├── preflight.ts               # Pre-flight dependency checks
+    ├── project-detection.ts       # Auto-detect language/framework/PM
+    ├── format.ts                  # Output formatting (tables, colors)
+    ├── session-utils.ts           # Session resolution helpers
+    └── ...
+```
+
+## WHERE TO LOOK
+
+| Task | Start here |
+|------|-----------|
+| Add new command | Create `commands/foo.ts`, register in `program.ts` |
+| Change spawn flow | `commands/spawn.ts` → `lib/create-session-manager.ts` |
+| Modify service management | `lib/services.ts` — handles systemd + supervisor fallback |
+| Change output formatting | `lib/format.ts` |
+| Plugin loading | `lib/plugins.ts` — registers all built-in plugins |
+
+## CONVENTIONS
+
+- `no-console` is OFF for this package — CLI uses console for user output
+- All commands load config via `lib/create-session-manager.ts` → builds full plugin stack
+- Templates in `templates/rules/` — agent rule files injected during `init`
+- Spinner via `ora` for async operations
+- Colors via `chalk`
+- Exit codes: 0 success, 1 error — never `process.exit()` in command handlers, throw instead

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -1,0 +1,73 @@
+# @syntese/core
+
+Engine library. Every other package depends on this. Exports types, config loader, session/lifecycle managers, plugin registry, and utilities.
+
+## KEY FILES
+
+| File | Role | Size |
+|------|------|------|
+| `src/types.ts` | ALL plugin interfaces + session/event types — the contract | 1591 lines |
+| `src/lifecycle-manager.ts` | Central state machine: polls sessions, detects transitions, fires reactions | ~117KB |
+| `src/session-manager.ts` | Session CRUD: spawn, list, kill, send, restore, claim-PR | Large |
+| `src/config.ts` | Loads + validates `syntese.yaml` with Zod schemas | — |
+| `src/plugin-registry.ts` | Plugin discovery, loading, slot registration | — |
+| `src/metadata.ts` | Flat-file key=value read/write (atomic writes via temp file) | — |
+| `src/paths.ts` | Hash-based directory derivation from config location | — |
+| `src/account-capacity.ts` | Multi-account quota tracking, usage estimation, account selection | — |
+| `src/accounts.ts` | Account registry, auth isolation, environment injection | — |
+| `src/verification.ts` | Post-push verification execution, merge gating | — |
+| `src/decomposer.ts` | LLM-driven issue decomposition into subtask trees | — |
+| `src/prompt-builder.ts` | Layered prompt composition for agent sessions | — |
+| `src/recovery/` | Session crash detection + auto-restore (scanner, validator, actions) | — |
+
+## PLUGIN SYSTEM (8 SLOTS)
+
+```
+1. Runtime    — where sessions execute    (tmux, process)
+2. Agent      — AI coding tool adapter    (claude-code, codex, aider, opencode)
+3. Workspace  — code isolation method     (worktree, clone)
+4. Tracker    — issue tracking            (github, linear, gitlab)
+5. SCM        — PR/CI/review platform     (github, gitlab)
+6. Notifier   — push notifications        (desktop, slack, webhook, openclaw)
+7. Terminal   — human interaction UI      (iterm2, web)
+8. Lifecycle  — state machine (core, not pluggable)
+```
+
+Every plugin exports `PluginModule<T>` with `manifest` + `create()`. The `T` is the slot interface (e.g., `Agent`, `Runtime`).
+
+## DATA FLOW
+
+```
+syntese.yaml → config.ts (Zod parse) → PluginRegistry (load plugins)
+                                      → SessionManager (CRUD via metadata.ts)
+                                      → LifecycleManager (poll loop → reactions)
+```
+
+State lives in `~/.syntese/{hash}-{projectId}/sessions/{sessionId}` as key=value files. No database.
+
+## WHERE TO LOOK
+
+| Task | Start here |
+|------|-----------|
+| Add session status | `types.ts` → `SessionStatus` union type + `SESSION_STATUS` const |
+| Add plugin interface | `types.ts` → new interface section + `PluginSlot` union |
+| Change reaction logic | `lifecycle-manager.ts` → reaction handler methods |
+| Modify session spawn | `session-manager.ts` → `spawn()` method |
+| Change config schema | `config.ts` → Zod schemas |
+| Add metadata field | `types.ts` → `SessionMetadata` interface + `metadata.ts` |
+| Change path derivation | `paths.ts` — hash = SHA256(configDir).slice(0, 12) |
+
+## CONVENTIONS
+
+- Exports via barrel `index.ts` — add new exports there, not directly from consumer
+- `tsconfig.build.json` excludes `__tests__/` from dist — tests never ship
+- Dependencies: only `@anthropic-ai/sdk`, `yaml`, `zod` — keep minimal
+- Vitest config uses path aliases to resolve plugin packages to source (avoids circular devDeps)
+- Recovery module is self-contained: `recovery/index.ts` re-exports everything
+
+## ANTI-PATTERNS
+
+- Do NOT add database dependencies — flat-file metadata is intentional
+- Do NOT split `lifecycle-manager.ts` — monolithic state machine by design
+- Do NOT add runtime-specific logic to core — belongs in plugins
+- Atomic writes (`atomic-write.ts`) required for metadata — never write directly to session files

--- a/packages/plugins/AGENTS.md
+++ b/packages/plugins/AGENTS.md
@@ -1,0 +1,74 @@
+# plugins/
+
+20 plugin packages across 8 slots. Each implements one interface from `@syntese/core/types.ts`.
+
+## SLOT → PLUGINS MAP
+
+| Slot | Plugins | Interface |
+|------|---------|-----------|
+| Agent | claude-code, codex, aider, opencode | `Agent` |
+| Runtime | tmux, process | `Runtime` |
+| Workspace | worktree, clone | `Workspace` |
+| Tracker | github, linear, gitlab | `Tracker` |
+| SCM | github, gitlab | `SCM` |
+| Notifier | desktop, slack, webhook, openclaw, composio | `Notifier` |
+| Terminal | iterm2, web | `Terminal` |
+
+## PLUGIN ANATOMY
+
+Every plugin follows the same pattern:
+
+```
+plugin-{slot}-{name}/
+├── package.json      # name: @syntese/plugin-{slot}-{name}
+├── src/
+│   └── index.ts      # Exports: { manifest, create }
+├── tsconfig.json     # Extends ../../tsconfig.base.json (NOT root)
+└── test/             # Optional tests (some use root integration-tests instead)
+```
+
+**Minimal implementation:**
+```typescript
+import type { PluginModule, PluginManifest, Notifier } from "@syntese/core/types";
+
+const manifest: PluginManifest = {
+  name: "my-notifier",
+  slot: "notifier",
+  description: "My custom notifier",
+  version: "0.1.0",
+};
+
+function create(config?: Record<string, unknown>): Notifier {
+  return {
+    name: manifest.name,
+    async notify(event) { /* ... */ },
+  };
+}
+
+export default { manifest, create } satisfies PluginModule<Notifier>;
+```
+
+## CONVENTIONS
+
+- Package name: `@syntese/plugin-{slot}-{name}` (e.g., `@syntese/plugin-agent-codex`)
+- Single dependency allowed: `@syntese/core` via `workspace:*`
+- Slot-specific deps are fine (e.g., `node-notifier` for desktop, `@linear/sdk` for linear)
+- Registration happens in `packages/cli/src/lib/plugins.ts` — add new plugins there
+- `tsconfig.json` extends `../../tsconfig.base.json` (two levels up from plugins dir)
+- Tests: either `test/` dir inside plugin or integration tests in `packages/integration-tests/`
+
+## WHERE TO LOOK
+
+| Task | Start here |
+|------|-----------|
+| Create new plugin | Copy closest existing plugin, change manifest + create() |
+| Understand interface | `packages/core/src/types.ts` — search for the slot interface |
+| Register plugin | `packages/cli/src/lib/plugins.ts` + add to CLI `package.json` deps |
+| Integration test | `packages/integration-tests/src/{slot}-{name}.integration.test.ts` |
+
+## NOTABLE PLUGINS
+
+- **agent-claude-code**: Largest plugin (~40KB). Handles JSONL activity detection, usage snapshots, workspace hooks, pricing estimation
+- **scm-github**: Rich interface (PR lifecycle, CI checks, reviews, merge readiness) — uses `gh` CLI
+- **runtime-tmux**: Core runtime. Creates tmux sessions with hash-prefixed names
+- **terminal-web**: Bridges web dashboard to tmux via plugin registry

--- a/packages/web/AGENTS.md
+++ b/packages/web/AGENTS.md
@@ -1,0 +1,78 @@
+# @syntese/web
+
+Next.js 15 dashboard + terminal WebSocket servers. Private package (not published to npm).
+
+## STRUCTURE
+
+```
+src/
+├── app/                    # Next.js App Router
+│   ├── layout.tsx              # Root layout (IBM Plex Sans/Mono fonts)
+│   ├── page.tsx                # Dashboard home (async SSR, force-dynamic)
+│   ├── globals.css             # Tailwind v4 imports
+│   ├── api/                    # Route handlers (11 endpoints)
+│   │   ├── sessions/route.ts       # GET: list sessions + PR enrichment
+│   │   ├── events/route.ts         # GET: SSE stream (5s snapshots, 15s heartbeat)
+│   │   ├── spawn/route.ts          # POST: spawn new session
+│   │   └── ...
+│   └── sessions/[id]/page.tsx  # Session detail view
+├── components/             # React 19 client components
+│   ├── Dashboard.tsx           # Main view (tabs, backlog, session grid) ~30KB
+│   ├── SessionDetail.tsx       # Detail view (terminal, PR, CI) ~30KB
+│   ├── DirectTerminal.tsx      # XDA-capable terminal component ~24KB
+│   ├── SessionCard.tsx         # Card with status, PR, activity
+│   ├── UsageDials.tsx          # Quota visualization
+│   └── ...
+├── lib/                    # Utilities
+│   ├── services.ts             # Singleton: config → plugins → managers (cached in globalThis)
+│   ├── serialize.ts            # Core Session → DashboardSession (Date→string, PR enrichment)
+│   ├── cache.ts                # TTL cache for PR data (5min, reduces GitHub API calls)
+│   ├── types.ts                # DashboardSession, DashboardPR types
+│   └── ...
+└── hooks/
+    └── useSessionEvents.ts     # SSE hook (useReducer for real-time state patches)
+
+server/                     # Standalone WebSocket servers (NOT Next.js)
+├── terminal-websocket.ts       # ttyd-based terminal (port 14800)
+├── direct-terminal-ws.ts       # node-pty direct terminal (port 14801, XDA support)
+└── tmux-utils.ts               # Shared tmux helpers
+
+e2e/                        # Playwright screenshots
+```
+
+## DATA FLOW
+
+```
+page.tsx (SSR) → services.ts (singleton) → core SessionManager
+                                         → serialize.ts (enrichment + caching)
+                                         → Dashboard.tsx (client hydration)
+                                         → useSessionEvents.ts (SSE for live updates)
+```
+
+No database. Server reads flat-file metadata from `~/.syntese/` via core.
+
+## WHERE TO LOOK
+
+| Task | Start here |
+|------|-----------|
+| Add dashboard feature | `components/Dashboard.tsx` |
+| Add API endpoint | `src/app/api/{name}/route.ts` — init services via `lib/services.ts` |
+| Change real-time updates | `src/app/api/events/route.ts` + `hooks/useSessionEvents.ts` |
+| Modify PR enrichment | `lib/serialize.ts` → `enrichSessionPR()` |
+| Terminal changes | `server/direct-terminal-ws.ts` (preferred) or `terminal-websocket.ts` |
+
+## CONVENTIONS
+
+- `no-console` OFF — server logs via console
+- `force-dynamic` on pages — no static generation (live data)
+- Services singleton in `globalThis.__syntese_services` — HMR-safe
+- PR data cached 5min via `TTLCache` to avoid GitHub rate limits
+- Tailwind v4 via `@tailwindcss/postcss` (not v3 config-based)
+- Testing: Vitest + jsdom + @testing-library/react, setup in `src/__tests__/setup.ts`
+- `dev` script runs 3 processes concurrently: Next.js + 2 terminal WS servers
+
+## ANTI-PATTERNS
+
+- Do NOT use static rendering — all pages need live session data
+- Do NOT import `@syntese/core` client-side — it uses Node APIs. Use serialized types
+- Terminal auth is TODO — do not assume authenticated access


### PR DESCRIPTION
## Summary

- Add 5 AGENTS.md files forming a hierarchical knowledge base for AI agents working on this codebase
- Remove `AGENTS.md` from `.gitignore` to allow versioning

## Files

| File | Lines | Scope |
|------|-------|-------|
| `./AGENTS.md` | 97 | Root: overview, structure, conventions, git workflow, anti-patterns, commands |
| `packages/core/AGENTS.md` | 73 | Core engine: types, lifecycle, plugin system, data flow |
| `packages/cli/AGENTS.md` | 54 | CLI: command structure, lib utilities, conventions |
| `packages/web/AGENTS.md` | 78 | Dashboard: App Router, components, terminal servers, data flow |
| `packages/plugins/AGENTS.md` | 74 | Plugins: slot map, anatomy, conventions, notable plugins |

## Key additions

- **Git Workflow (MANDATORY)**: Worktree-based isolation, conventional commits, PR-only merges
- **WHERE TO LOOK** tables: Task → file mapping for quick navigation
- **Anti-patterns**: Project-specific forbidden patterns
- No redundancy between parent and child files — children only document package-specific deviations