### PR TITLE
fix: repair YAML block scalar in auto-rebase workflow

### DIFF
--- a/.github/workflows/ai-auto-rebase.yml
+++ b/.github/workflows/ai-auto-rebase.yml
@@ -72,16 +72,19 @@ jobs:
                 git rebase --abort 2>/dev/null || true
 
                 # Post context so the AI knows exactly what to fix
-                gh issue comment "$issue_num" --body "## ⚠️ Merge Conflicts — Fix Needed
-
-**Branch:** \`$branch\` (PR #$number still open — resolve conflicts on existing branch, don't start fresh)
-
-**Conflicts:**
-\`\`\`
-$conflict_files
-\`\`\`
-
-**Action:** Relabeled to \`ai-task\`. Orchestrator will pick this up — check out the existing branch, run \`git rebase origin/main\`, resolve the conflicts, force-push. Do NOT create a new branch or PR."
+                {
+                  echo "## ⚠️ Merge Conflicts — Fix Needed"
+                  echo ""
+                  echo "**Branch:** \`$branch\` (PR #$number still open — resolve conflicts on existing branch, don't start fresh)"
+                  echo ""
+                  echo "**Conflicts:**"
+                  echo '```'
+                  echo "$conflict_files"
+                  echo '```'
+                  echo ""
+                  echo "**Action:** Relabeled to \`ai-task\`. Orchestrator will pick this up — check out the existing branch, run \`git rebase origin/main\`, resolve the conflicts, force-push. Do NOT create a new branch or PR."
+                } > /tmp/rebase-comment-body.md
+                gh issue comment "$issue_num" --body-file /tmp/rebase-comment-body.md
 
                 gh pr comment "$number" --body "⚠️ Auto-rebase failed due to merge conflicts. Issue #$issue_num relabeled for the orchestrator to resolve conflicts on this branch."
 


### PR DESCRIPTION
The multi-line `gh issue comment --body` string dropped to column 0 indentation, breaking the YAML block scalar (`run: |`). GitHub couldn't parse the workflow at all — every run failed with 0 jobs and 0s runtime.

**Root cause:** Lines 76-85 (the markdown body for conflict comments) had zero indentation inside the `run: |` block. YAML interprets `**` at column 0 as an alias token, making the entire file unparseable.

**Fix:** Build the comment body via `echo` statements into a temp file and use `--body-file` instead of an inline multi-line string. All lines stay properly indented under the block scalar.